### PR TITLE
Jcll branch for RubyRTL reference

### DIFF
--- a/index.md
+++ b/index.md
@@ -3,388 +3,616 @@ layout: default
 title: The Ruby Bibliography
 ---
 
-# Virtual Machines and Compilers
+### Virtual Machines and Compilers
 
-[#](#daloze2019) B. Daloze. **[Thread-Safe and Efficient Data Representations in Dynamically-Typed Languages](https://eregon.me/blog/assets/research/thesis-thread-safe-data-representations-in-dynamic-languages.pdf)**. PhD thesis, Johannes Kepler University Linz, 2019.
-
+<a class="paper" name="daloze2019" href="#daloze2019">#</a>
+B. Daloze.
+**[Thread-Safe and Efficient Data Representations in Dynamically-Typed Languages](https://eregon.me/blog/assets/research/thesis-thread-safe-data-representations-in-dynamic-languages.pdf)**.
+PhD thesis, Johannes Kepler University Linz, 2019.
 <span class="badge badge-warning">TruffleRuby</span>
 
-[#](#mosaner2019) R. Mosaner, D. Leopoldseder, M. Rigger, R. Schatz, H. Mössenböck. **[Supporting On-Stack Replacement in Unstructured Languages by Loop Reconstruction and Extraction](https://arxiv.org/pdf/1909.08815.pdf)**. In Proceedings of the 16th International Conference on Managed Programming Languages and Runtimes (MPLR), 2019.
-
+<a class="paper" name="mosaner2019" href="#mosaner2019">#</a>
+R. Mosaner, D. Leopoldseder, M. Rigger, R. Schatz, H. Mössenböck.
+**[Supporting On-Stack Replacement in Unstructured Languages by Loop Reconstruction and Extraction](https://arxiv.org/pdf/1909.08815.pdf)**.
+In Proceedings of the 16th International Conference on Managed Programming Languages and Runtimes (MPLR), 2019.
 <span class="badge badge-warning">TruffleRuby</span>
 
-[#](#sasada2019) K. Sasada. **[Gradual Write-Barrier Insertion into a Ruby interpreter](https://www.atdot.net/~ko1/activities/rgengc_ismm.pdf)**. In Proceedings of the International Symposium on Memory Management (ISMM), 2019.
-
+<a class="paper" name="sasada2019" href="#sasada2019">#</a>
+K. Sasada.
+**[Gradual Write-Barrier Insertion into a Ruby interpreter](https://www.atdot.net/~ko1/activities/rgengc_ismm.pdf)**.
+In Proceedings of the International Symposium on Memory Management (ISMM), 2019.
 <span class="badge badge-danger">MRI</span>
 
-[#](#sugiyama2018) K. Sugiyama, K. Sasada, M. J. Dürst. **[Dynamic Extension of the Ruby Virtual Machine Stack](https://ipsj.ixsq.nii.ac.jp/ej/index.php?active_action=repository_view_main_item_detail&page_id=13&block_id=8&item_id=191427&item_no=1)**. In the IPSJ Journal of Programming (PRO), 2018\. _In Japanese_.
-
+<a class="paper" name="sugiyama2018" href="#sugiyama2018">#</a>
+K. Sugiyama, K. Sasada, M. J. Dürst.
+**[Dynamic Extension of the Ruby Virtual Machine Stack](https://ipsj.ixsq.nii.ac.jp/ej/index.php?active_action=repository_view_main_item_detail&page_id=13&block_id=8&item_id=191427&item_no=1)**.
+In the IPSJ Journal of Programming (PRO), 2018. *In Japanese*.
 <span class="badge badge-danger">MRI</span>
-
 <!-- link is flaky -->
 
- [#](#menard2018) K. Menard, C. Seaton, B. Daloze. **[Specializing Ropes for Ruby](https://chrisseaton.com/truffleruby/ropes-manlang.pdf)**. In Proceedings of 15th International Conference on Managed Languages & Runtimes (ManLang), 2018.
-
+<a class="paper" name="menard2018" href="#menard2018">#</a>
+K. Menard, C. Seaton, B. Daloze.
+**[Specializing Ropes for Ruby](https://chrisseaton.com/truffleruby/ropes-manlang.pdf)**.
+In Proceedings of 15th International Conference on Managed Languages & Runtimes (ManLang), 2018.
 <span class="badge badge-warning">TruffleRuby</span>
 
-[#](#grimmer2018) M. Grimmer, R. Schatz, C. Seaton, T. Würthinger, M. Luján. **[Cross-Language Interoperability in a Multi-Language Runtime](https://chrisseaton.com/truffleruby/cross-language-interop.pdf)**. In ACM Transactions on Programming Languages and Systems (TOPLAS), Vol. 40, No. 2, 2018.
-
+<a class="paper" name="grimmer2018" href="#grimmer2018">#</a>
+M. Grimmer, R. Schatz, C. Seaton, T. Würthinger, M. Luján.
+**[Cross-Language Interoperability in a Multi-Language Runtime](https://chrisseaton.com/truffleruby/cross-language-interop.pdf)**.
+In ACM Transactions on Programming Languages and Systems (TOPLAS), Vol. 40, No. 2, 2018.
 <span class="badge badge-warning">TruffleRuby</span>
 
-[#](#yang2017) B. Yang, J. Kim, S. Moon. **[Exceptionalization: A Java VM Optimization for Non-Java Languages](https://dl.acm.org/doi/10.1145/3046681)**. In ACM Transactions on Architecture and Code Optimization (TACO), volume 14, issue 1, 2017.
-
+<a class="paper" name="yang2017" href="#yang2017">#</a>
+B. Yang, J. Kim, S. Moon.
+**[Exceptionalization: A Java VM Optimization for Non-Java Languages](https://dl.acm.org/doi/10.1145/3046681)**.
+In ACM Transactions on Architecture and Code Optimization (TACO), volume 14, issue 1, 2017.
 <span class="badge badge-info">JRuby</span>
-
 <span class="badge badge-dark">Paywall</span>
 
-[#](#xu2017) S. Xu, D. Bremner, D. Heidinga. **[Fusing Method Handle Graphs for Efficient Dynamic JVM Language Implementations](https://xushijie.github.io/papers/vmil17.pdf)**. In Proceedings of the 9th ACM SIGPLAN International Workshop on Virtual Machines and Intermediate Languages (VMIL), 2017.
-
+<a class="paper" name="xu2017" href="#xu2017">#</a>
+S. Xu, D. Bremner, D. Heidinga.
+**[Fusing Method Handle Graphs for Efficient Dynamic JVM Language Implementations](https://xushijie.github.io/papers/vmil17.pdf)**.
+In Proceedings of the 9th ACM SIGPLAN International Workshop on Virtual Machines and Intermediate Languages (VMIL), 2017.
 <span class="badge badge-info">JRuby</span>
 
-[#](#wuerthinger2017) T. Würthinger, C. Wimmer, C. Humer, A. Wöss, L. Stadler, C. Seaton, G. Duboscq, D. Simon, M. Grimmer. **[Practical Partial Evaluation for High-Performance Dynamic Language Runtimes](https://chrisseaton.com/rubytruffle/pldi17-truffle/pldi17-truffle.pdf)**. In Proceedings of the 38th Conference on Programming Language Design and Implementation (PLDI), 2017.
-
+<a class="paper" name="wuerthinger2017" href="#wuerthinger2017">#</a>
+T. Würthinger, C. Wimmer, C. Humer, A. Wöss, L. Stadler, C. Seaton, G. Duboscq, D. Simon, M. Grimmer.
+**[Practical Partial Evaluation for High-Performance Dynamic Language Runtimes](https://chrisseaton.com/rubytruffle/pldi17-truffle/pldi17-truffle.pdf)**.
+In Proceedings of the 38th Conference on Programming Language Design and Implementation (PLDI), 2017.
 <span class="badge badge-warning">TruffleRuby</span>
 
-[#](#georgiou2017) S. Georgiou, M. Kechagia, D. Spinellis. **[Analyzing Programming Languages' Energy Consumption: An Empirical Study](https://stefanos1316.github.io/my_curriculum_vitae/GKS17.pdf)**. In Proceedings of the 21st Pan-Hellenic Conference on Informatics (PCI), 2017.
+<a class="paper" name="georgiou2017" href="#georgiou2017">#</a>
+S. Georgiou, M. Kechagia, D. Spinellis.
+**[Analyzing Programming Languages' Energy Consumption: An Empirical Study](https://stefanos1316.github.io/my_curriculum_vitae/GKS17.pdf)**.
+In Proceedings of the 21st Pan-Hellenic Conference on Informatics (PCI), 2017.
 
-[#](#marr2016) S. Marr, B. Daloze, H. Mössenböck. **[Cross-Language Compiler Benchmarking - Are We Fast Yet?](https://stefan-marr.de/downloads/dls16-marr-et-al-cross-language-compiler-benchmarking-are-we-fast-yet.pdf)** In Proceedings of the 12th Dynamic Languages Symposium (DLS), 2016.
+<a class="paper" name="marr2016" href="#marr2016">#</a>
+S. Marr, B. Daloze, H. Mössenböck.
+**[Cross-Language Compiler Benchmarking - Are We Fast Yet?](https://stefan-marr.de/downloads/dls16-marr-et-al-cross-language-compiler-benchmarking-are-we-fast-yet.pdf)** In Proceedings of the 12th Dynamic Languages Symposium (DLS), 2016.
+<span class="badge badge-warning">TruffleRuby</span> <span class="badge badge-info">JRuby</span> <span class="badge badge-secondary">Rubinius</span> <span class="badge badge-danger">MRI</span>
 
+<a class="paper" name="seaton2016" href="#seaton2016">#</a>
+C. Seaton.
+**[AST Specialisation and Partial Evaluation for Easy High-Performance Metaprogramming](https://chrisseaton.com/rubytruffle/meta16/meta16-ruby.pdf)**.
+In Proceedings of the 1st Workshop on Meta-Programming Techniques and Reflection (META), 2016.
 <span class="badge badge-warning">TruffleRuby</span>
 
+<a class="paper" name="xu2016" href="#xu2016">#</a>
+S. Xu, D. Bremner, D. Heidinga.
+**[MHDeS: Deduplicating Method Handle Graphs for Efficient Dynamic JVM Language Implementations](https://xushijie.github.io/papers/deduplication.pdf)**.
+In Proceedings of the 11th Workshop on Implementation, Compilation, Optimization of Object-Oriented Languages, Programs and Systems (ICOOOLPS), 2016.
 <span class="badge badge-info">JRuby</span>
 
-<span class="badge badge-secondary">Rubinius</span>
-
+<a class="paper" name="ide2015a" href="#ide2015a">#</a>
+M. Ide.
+**[Study on Method-based and Trace-based Just-in-time Compilation for Scripting Languages](https://ynu.repo.nii.ac.jp/?action=repository_action_common_download&item_id=4714&item_no=1&attribute_id=20&file_no=1)**.
+PhD thesis, Yokohama National University, 2015.
 <span class="badge badge-danger">MRI</span>
 
-[#](#seaton2016) C. Seaton. **[AST Specialisation and Partial Evaluation for Easy High-Performance Metaprogramming](https://chrisseaton.com/rubytruffle/meta16/meta16-ruby.pdf)**. In Proceedings of the 1st Workshop on Meta-Programming Techniques and Reflection (META), 2016.
-
-<span class="badge badge-warning">TruffleRuby</span>
-
-[#](#xu2016) S. Xu, D. Bremner, D. Heidinga. **[MHDeS: Deduplicating Method Handle Graphs for Efficient Dynamic JVM Language Implementations](https://xushijie.github.io/papers/deduplication.pdf)**. In Proceedings of the 11th Workshop on Implementation, Compilation, Optimization of Object-Oriented Languages, Programs and Systems (ICOOOLPS), 2016.
-
-<span class="badge badge-info">JRuby</span>
-
-[#](#ide2015a) M. Ide. **[Study on Method-based and Trace-based Just-in-time Compilation for Scripting Languages](https://ynu.repo.nii.ac.jp/?action=repository_action_common_download&item_id=4714&item_no=1&attribute_id=20&file_no=1)**. PhD thesis, Yokohama National University, 2015.
-
+<a class="paper" name="ide2015b" href="#ide2015b">#</a>
+M. Ide, K. Kuramitsu.
+**[A Trace-based Just-in-time Compiler for Ruby](https://kuramitsulab.github.io/paper/rujit.pdf)**.
+In Journal of Information Processing Society of Japan, Transactions on Programming, 2015. *In Japanese*.
 <span class="badge badge-danger">MRI</span>
 
-[#](#ide2015b) M. Ide, K. Kuramitsu. **[A Trace-based Just-in-time Compiler for Ruby](https://kuramitsulab.github.io/paper/rujit.pdf)**. In Journal of Information Processing Society of Japan, Transactions on Programming, 2015\. _In Japanese_.
-
-<span class="badge badge-danger">MRI</span>
-
-[#](#tanaka2015) K. Tanaka, A. D. Nagumanthri, Y. Matsumoto. **[mruby – Rapid Software Development for Embedded Systems](https://www.researchgate.net/profile/Aviansh-Nagumanthri/publication/282816987_mruby_-_Rapid_Software_Development_for_Embedded_Systems/links/561f03e308ae50795aff64d0/mruby-Rapid-Software-Development-for-Embedded-Systems.pdf)**. In Proceedings of the 15th International Conference on Computational Science and its Applications (ICCSA), 2015.
-
+<a class="paper" name="tanaka2015" href="#tanaka2015">#</a>
+K. Tanaka, A. D. Nagumanthri, Y. Matsumoto.
+**[mruby – Rapid Software Development for Embedded Systems](https://www.researchgate.net/profile/Aviansh-Nagumanthri/publication/282816987_mruby_-_Rapid_Software_Development_for_Embedded_Systems/links/561f03e308ae50795aff64d0/mruby-Rapid-Software-Development-for-Embedded-Systems.pdf)**.
+In Proceedings of the 15th International Conference on Computational Science and its Applications (ICCSA), 2015.
 <span class="badge badge-success">mruby</span>
 
-[#](#xu2015) S. Xu, D. Bremner, D. Heidinga. **[Mining Method Handle Graphs for Efficient Dynamic JVM Languages](https://xushijie.github.io/papers/mh_mining.pdf)**. In ACM proceedings 12th Conference on Principles and Practices of Programming on the Java Platform (PPPJ), 2015.
-
+<a class="paper" name="xu2015" href="#xu2015">#</a>
+S. Xu, D. Bremner, D. Heidinga.
+**[Mining Method Handle Graphs for Efficient Dynamic JVM Languages](https://xushijie.github.io/papers/mh_mining.pdf)**.
+In ACM proceedings 12th Conference on Principles and Practices of Programming on the Java Platform (PPPJ), 2015.
 <span class="badge badge-info">JRuby</span>
 
-[#](#viering2015) M. Viering. **[An Efficient Runtime System for Reactive Programming](http://mviering.de/reactiveruby.pdf)**. Master thesis, Technische Universität Darmstadt, 2015.
-
+<a class="paper" name="viering2015" href="#viering2015">#</a>
+M. Viering.
+**[An Efficient Runtime System for Reactive Programming](http://mviering.de/reactiveruby.pdf)**.
+Master thesis, Technische Universität Darmstadt, 2015.
 <span class="badge badge-warning">TruffleRuby</span>
 
-[#](#seaton2015) C. Seaton. **[Specialising Dynamic Techniques for Implementing the Ruby Programming Language](https://chrisseaton.com/phd/specialising-ruby.pdf)**. PhD thesis, University of Manchester, 2015.
-
+<a class="paper" name="seaton2015" href="#seaton2015">#</a>
+C. Seaton.
+**[Specialising Dynamic Techniques for Implementing the Ruby Programming Language](https://chrisseaton.com/phd/specialising-ruby.pdf)**.
+PhD thesis, University of Manchester, 2015.
 <span class="badge badge-warning">TruffleRuby</span>
 
-[#](#grimmer2015b) M. Grimmer, C. Seaton, R. Schatz, T. Würthinger, H. Mössenböck. **[High-Performance Cross-Language Interoperability in a Multi-Language Runtime](https://chrisseaton.com/rubytruffle/dls15-interop/dls15-interop.pdf)**. In Proceedings of the 11th Dynamic Languages Symposium (DLS), 2015.
-
+<a class="paper" name="grimmer2015b" href="#grimmer2015b">#</a>
+M. Grimmer, C. Seaton, R. Schatz, T. Würthinger, H. Mössenböck.
+**[High-Performance Cross-Language Interoperability in a Multi-Language Runtime](https://chrisseaton.com/rubytruffle/dls15-interop/dls15-interop.pdf)**.
+In Proceedings of the 11th Dynamic Languages Symposium (DLS), 2015.
 <span class="badge badge-warning">TruffleRuby</span>
 
-[#](#niephaus2015) F. Niephaus, M. Springer, T. Felgentreff, T. Pape, R. Hirschfeld. **[Call-target-specific Method Arguments](https://raw.githubusercontent.com/HPI-SWA-Lab/TargetSpecific-ICOOOLPS/gh-pages/call_target_specific_method_arguments.pdf)**. In Proceedings of the 10th Implementation, Compilation, Optimization of Object-Oriented Languages, Programs and Systems Workshop (ICOOOLPS), 2015.
-
+<a class="paper" name="niephaus2015" href="#niephaus2015">#</a>
+F. Niephaus, M. Springer, T. Felgentreff, T. Pape, R. Hirschfeld.
+**[Call-target-specific Method Arguments](https://raw.githubusercontent.com/HPI-SWA-Lab/TargetSpecific-ICOOOLPS/gh-pages/call_target_specific_method_arguments.pdf)**.
+In Proceedings of the 10th Implementation, Compilation, Optimization of Object-Oriented Languages, Programs and Systems Workshop (ICOOOLPS), 2015.
 <span class="badge badge-warning">TruffleRuby</span>
 
-[#](#daloze2015) B. Daloze, C. Seaton, D. Bonetta, H. Mössenböck. **[Techniques and Applications for Guest-Language Safepoints](https://chrisseaton.com/rubytruffle/icooolps15-safepoints/safepoints.pdf)**. In Proceedings of the 10th Implementation, Compilation, Optimization of Object-Oriented Languages, Programs and Systems Workshop (ICOOOLPS), 2015.
-
+<a class="paper" name="daloze2015" href="#daloze2015">#</a>
+B. Daloze, C. Seaton, D. Bonetta, H. Mössenböck.
+**[Techniques and Applications for Guest-Language Safepoints](https://chrisseaton.com/rubytruffle/icooolps15-safepoints/safepoints.pdf)**.
+In Proceedings of the 10th Implementation, Compilation, Optimization of Object-Oriented Languages, Programs and Systems Workshop (ICOOOLPS), 2015.
 <span class="badge badge-warning">TruffleRuby</span>
 
-[#](#marr2015) S. Marr, C. Seaton, S. Ducasse. **[Zero-Overhead Metaprogramming: Reflection and Metaobject Protocols Fast and without Compromises](https://chrisseaton.com/rubytruffle/pldi15-metaprogramming/pldi15-marr-et-al-zero-overhead-metaprogramming.pdf)**. In Proceedings of the 36th Conference on Programming Language Design and Implementation (PLDI), 2015.
-
+<a class="paper" name="marr2015" href="#marr2015">#</a>
+S. Marr, C. Seaton, S. Ducasse.
+**[Zero-Overhead Metaprogramming: Reflection and Metaobject Protocols Fast and without Compromises](https://chrisseaton.com/rubytruffle/pldi15-metaprogramming/pldi15-marr-et-al-zero-overhead-metaprogramming.pdf)**.
+In Proceedings of the 36th Conference on Programming Language Design and Implementation (PLDI), 2015.
 <span class="badge badge-warning">TruffleRuby</span>
 
-[#](#grimmer2015a) M. Grimmer, C. Seaton, T. Würthinger, H. Mössenböck. **[Dynamically Composing Languages in a Modular Way: Supporting C Extensions for Dynamic Languages](https://chrisseaton.com/rubytruffle/modularity15/rubyextensions.pdf)**. In Proceedings of the 14th International Conference on Modularity, 2015.
-
+<a class="paper" name="grimmer2015a" href="#grimmer2015a">#</a>
+M. Grimmer, C. Seaton, T. Würthinger, H. Mössenböck.
+**[Dynamically Composing Languages in a Modular Way: Supporting C Extensions for Dynamic Languages](https://chrisseaton.com/rubytruffle/modularity15/rubyextensions.pdf)**.
+In Proceedings of the 14th International Conference on Modularity, 2015.
 <span class="badge badge-warning">TruffleRuby</span>
 
-[#](#woess2014) A. Wöß, C. Wirth, D. Bonetta, C. Seaton, C. Humer, H. Mössenböck. **[An Object Storage Model for the Truffle Language Implementation Framework](https://chrisseaton.com/rubytruffle/pppj14-om/pppj14-om.pdf)**. In Proceedings of the International Conference on Principles and Practices of Programming on the Java Platform (PPPJ), 2014.
-
+<a class="paper" name="woess2014" href="#woess2014">#</a>
+A. Wöß, C. Wirth, D. Bonetta, C. Seaton, C. Humer, H. Mössenböck.
+**[An Object Storage Model for the Truffle Language Implementation Framework](https://chrisseaton.com/rubytruffle/pppj14-om/pppj14-om.pdf)**.
+In Proceedings of the International Conference on Principles and Practices of Programming on the Java Platform (PPPJ), 2014.
 <span class="badge badge-warning">TruffleRuby</span>
 
-[#](#sarimbekov2013) A. Sarimbekov, A. Podzimek, L. Bulej, Y. Zheng, N. Ricci, W. Binder. **[Characteristics of Dynamic JVM Languages](http://design.cs.iastate.edu/vmil/2013/papers/p05-Sarimbekov.pdf)**. In Proceedings of the 7th Workshop on Virtual Machines and Intermediate Languages (VMIL), 2013.
-
+<a class="paper" name="sarimbekov2013" href="#sarimbekov2013">#</a>
+A. Sarimbekov, A. Podzimek, L. Bulej, Y. Zheng, N. Ricci, W. Binder.
+**[Characteristics of Dynamic JVM Languages](http://design.cs.iastate.edu/vmil/2013/papers/p05-Sarimbekov.pdf)**.
+In Proceedings of the 7th Workshop on Virtual Machines and Intermediate Languages (VMIL), 2013.
 <span class="badge badge-info">JRuby</span>
 
-[#](#hang2013) [W. Hang Li, D. R. White, J. Singer. _**_]()**[JVM-Hosted Languages: They Talk the Talk, but do they Walk the Walk?](http://www.dcs.gla.ac.uk/~jsinger/pdfs/pppj13.pdf)** In Proceedings of the International Conference on Principles and Practices of Programming on the Java Platform (PPPJ), 2013.
-
+<a class="paper" name="hang2013" href="#hang2013">#</a>
+<a name="talk-talk">W. Hang Li, D. R. White, J. Singer.
+**[JVM-Hosted Languages: They Talk the Talk, but do they Walk the Walk?](http://www.dcs.gla.ac.uk/~jsinger/pdfs/pppj13.pdf)** In Proceedings of the International Conference on Principles and Practices of Programming on the Java Platform (PPPJ), 2013.
 <span class="badge badge-info">JRuby</span>
 
-[#](#springer2013) M. Springer. **[Inter-language Collaboration in an Object-oriented Virtual Machine](http://matthiasspringer.de/downloads/BP2012H1_intra-language_collaboration.pdf)**. Bachelor's thesis, Hasso-Plattner-Institute, 2013.
-
+<a class="paper" name="springer2013" href="#springer2013">#</a>
+M. Springer.
+**[Inter-language Collaboration in an Object-oriented Virtual Machine](http://matthiasspringer.de/downloads/BP2012H1_intra-language_collaboration.pdf)**.
+Bachelor's thesis, Hasso-Plattner-Institute, 2013.
 <span class="badge badge-primary">MagLev</span>
 
-[#](#castanos2012) J. Castanos, D. Edelsohn, K. Ishizaki, P. Nagpurkar, T. Nakatani, T. Ogasawara, P. Wu. **[On the Benefits and Pitfalls of Extending a Statically Typed Language JIT Compiler for Dynamic Scripting Languages](https://researcher.watson.ibm.com/researcher/files/us-pengwu/oopsla12-final-dsl.pdf)**. In Proceedings of the 20th Conference on Object-Oriented Programming, Systems, Languages, and Applications (OOPSLA), 2012.
+<a class="paper" name="castanos2012" href="#castanos2012">#</a>
+J. Castanos, D. Edelsohn, K. Ishizaki, P. Nagpurkar, T. Nakatani, T. Ogasawara, P. Wu.
+**[On the Benefits and Pitfalls of Extending a Statically Typed Language JIT Compiler for Dynamic Scripting Languages](https://researcher.watson.ibm.com/researcher/files/us-pengwu/oopsla12-final-dsl.pdf)**.
+In Proceedings of the 20th Conference on Object-Oriented Programming, Systems, Languages, and Applications (OOPSLA), 2012.
+<span class="badge badge-info">JRuby</span> <span class="badge badge-secondary">Rubinius</span>
 
-<span class="badge badge-info">JRuby</span>
-
-<span class="badge badge-secondary">Rubinius</span>
-
-[#](#shiba2012) S. Shiba, K. Sasada, K. Hiraki. **[CastOff: A Compiler for Ruby Implemented as a Library](https://ipsj.ixsq.nii.ac.jp/ej/?action=pages_view_main&active_action=repository_view_main_item_detail&item_id=83510&item_no=1&page_id=13&block_id=8)**. In Journal of Information Processing Society of Japan, Transactions on Programming, 2012\. _In Japanese_.
-
+<a class="paper" name="shiba2012" href="#shiba2012">#</a>
+S. Shiba, K. Sasada, K. Hiraki.
+**[CastOff: A Compiler for Ruby Implemented as a Library](https://ipsj.ixsq.nii.ac.jp/ej/?action=pages_view_main&active_action=repository_view_main_item_detail&item_id=83510&item_no=1&page_id=13&block_id=8)**.
+In Journal of Information Processing Society of Japan, Transactions on Programming, 2012. *In Japanese*.
 <span class="badge badge-danger">MRI</span>
-
 <!-- link is flaky -->
 
- [#](#shiba2011) S. Shiba, K. Sasada, S. Urabe, Y. Matsumoto, M. Inaba, K. Hiraki. **[A Practical AOT Compiler for Ruby](https://ipsj.ixsq.nii.ac.jp/ej/?action=pages_view_main&active_action=repository_view_main_item_detail&item_id=73661&item_no=1&page_id=13&block_id=8)**. In Journal of Information Processing Society of Japan, Transactions on Programming, 2011\. _In Japanese_.
-
+<a class="paper" name="shiba2011" href="#shiba2011">#</a>
+S. Shiba, K. Sasada, S. Urabe, Y. Matsumoto, M. Inaba, K. Hiraki.
+**[A Practical AOT Compiler for Ruby](https://ipsj.ixsq.nii.ac.jp/ej/?action=pages_view_main&active_action=repository_view_main_item_detail&item_id=73661&item_no=1&page_id=13&block_id=8)**.
+In Journal of Information Processing Society of Japan, Transactions on Programming, 2011. *In Japanese*.
 <span class="badge badge-danger">MRI</span>
-
 <!-- link is flaky -->
 
- [#](#zakirov2010) S. Zakirov, S. Chiba, E. Shibayama. **[How to Select Superinstructions for Ruby](https://www.researchgate.net/publication/239436707_How_to_Select_Superinstructions_for_Ruby)**. In Journal of Information Processing Society of Japan, Transactions on Programming, 2010.
-
+<a class="paper" name="zakirov2010" href="#zakirov2010">#</a>
+S. Zakirov, S. Chiba, E. Shibayama.
+**[How to Select Superinstructions for Ruby](https://www.researchgate.net/publication/239436707_How_to_Select_Superinstructions_for_Ruby)**.
+In Journal of Information Processing Society of Japan, Transactions on Programming, 2010.
 <span class="badge badge-danger">MRI</span>
 
-[#](#zakirov2010b) S. Zakirov, S. Chiba, E. Shibayama. **[Optimizing Dynamic Dispatch with Fine-grained State Tracking](https://dl.acm.org/doi/10.1145/1869631.1869634)**. In Proceedings of the Dynamic Language Symposium, 2010.
-
+<a class="paper" name="zakirov2010b" href="#zakirov2010b">#</a>
+S. Zakirov, S. Chiba, E. Shibayama.
+**[Optimizing Dynamic Dispatch with Fine-grained State Tracking](https://dl.acm.org/doi/10.1145/1869631.1869634)**.
+In Proceedings of the Dynamic Language Symposium, 2010.
 <span class="badge badge-dark">Paywall</span>
 
-[#](#furr2009) M. Furr, J. An, J. S. Foster, M. Hicks. **[The Ruby Intermediate Language](http://www.cs.umd.edu/projects/PL/druby/papers/druby-dls09.pdf)**. In Proceedings of the Dynamic Language Symposium, 2009.
+<a class="paper" name="furr2009" href="#furr2009">#</a>
+M. Furr, J. An, J. S. Foster, M. Hicks.
+**[The Ruby Intermediate Language](http://www.cs.umd.edu/projects/PL/druby/papers/druby-dls09.pdf)**.
+In Proceedings of the Dynamic Language Symposium, 2009.
 
-[#](#sasada2009) K. Sasada. **[Ricsin: A System for "C Mix-in to Ruby"](https://www.atdot.net/~ko1/activities/ricsin2009.pdf)**. In Proceedings of the IPSJ Programming Workshop, 2009\. _In Japanese_.
-
+<a class="paper" name="sasada2009" href="#sasada2009">#</a>
+K. Sasada.
+**[Ricsin: A System for “C Mix-in to Ruby”](https://www.atdot.net/~ko1/activities/ricsin2009.pdf)**.
+In Proceedings of the IPSJ Programming Workshop, 2009. *In Japanese*.
 <span class="badge badge-danger">MRI</span>
 
-[#](#sasada2008) K. Sasada. **[A Lightweight Representation of Floting-Point Numbers on Ruby Interpreter](https://www.atdot.net/~ko1/activities/rubyfp2008.pdf)**. In Proceedings of PPL, 2008\. _In Japanese_.
-
+<a class="paper" name="sasada2008" href="#sasada2008">#</a>
+K. Sasada.
+**[A Lightweight Representation of Floting-Point Numbers on Ruby Interpreter](https://www.atdot.net/~ko1/activities/rubyfp2008.pdf)**.
+In Proceedings of PPL, 2008. *In Japanese*.
 <span class="badge badge-danger">MRI</span>
 
-[#](#prokopski2008) G. B. Prokopski, C. Verbrugge. **[Analyzing the Performance of Code-Copying Virtual Machines](https://dl.acm.org/doi/10.1145/1449764.1449796)**. In Proceedings of the 23rd Conference on Object-Oriented Programming, Systems, Languages, and Applications (OOPSLA), 2008.
-
+<a class="paper" name="prokopski2008" href="#prokopski2008">#</a>
+G. B. Prokopski, C. Verbrugge.
+**[Analyzing the Performance of Code-Copying Virtual Machines](https://dl.acm.org/doi/10.1145/1449764.1449796)**.
+In Proceedings of the 23rd Conference on Object-Oriented Programming, Systems, Languages, and Applications (OOPSLA), 2008.
 <span class="badge badge-danger">MRI</span>
-
 <span class="badge badge-dark">Paywall</span>
 
-[#](#kelly2008) W. Kelly, J. Gough. **[Ruby.NET: a Ruby Compiler for the Common Language Infrastructure](http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.294.2678)**. In Proceedings of the 31st Australasian Conference on Computer Science, 2008.
+<a class="paper" name="kelly2008" href="#kelly2008">#</a>
+W. Kelly, J. Gough.
+**[Ruby.NET: a Ruby Compiler for the Common Language Infrastructure](http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.294.2678)**.
+In Proceedings of the 31st Australasian Conference on Computer Science, 2008.
 
-[#](#sasada2005b) K. Sasada, Y. Matsumoto, A. Maeda, M. Namiki. **[YARV: Yet Another RubyVM The Implementation and Evaluation](https://www.atdot.net/~ko1/activities/yarv2005vm.pdf)**. In the IPSJ Journal of Programming (PRO), 2005\. _In Japanese_.
-
+<a class="paper" name="sasada2005b" href="#sasada2005b">#</a>
+K. Sasada, Y. Matsumoto, A. Maeda, M. Namiki.
+**[YARV: Yet Another RubyVM The Implementation and Evaluation](https://www.atdot.net/~ko1/activities/yarv2005vm.pdf)**.
+In the IPSJ Journal of Programming (PRO), 2005. *In Japanese*.
 <span class="badge badge-danger">MRI</span>
 
-[#](#sasada2005) K. Sasada. **[YARV: Yet Another RubyVM: Innovating the Ruby Interpreter](https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.482.9851&rep=rep1&type=pdf)**. In Proceedings of the 20th Conference on Object-Oriented Programming, Systems, Languages, and Applications (OOPSLA), 2005.
-
+<a class="paper" name="sasada2005" href="#sasada2005">#</a>
+K. Sasada.
+**[YARV: Yet Another RubyVM: Innovating the Ruby Interpreter](https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.482.9851&rep=rep1&type=pdf)**.
+In Proceedings of the 20th Conference on Object-Oriented Programming, Systems, Languages, and Applications (OOPSLA), 2005.
 <span class="badge badge-danger">MRI</span>
 
-# Parallelism and Concurrency
+### Parallelism and Concurrency
 
-[#](#springer2019) M. Springer. **[Memory-Efficient Object-Oriented Programming on GPUs](https://m-sp.org/downloads/phd_thesis.pdf)**. PhD thesis, Tokyo Institute of Technology, 2019.
+<a class="paper" name="springer2019" href="#springer2019">#</a>
+M. Springer.
+**[Memory-Efficient Object-Oriented Programming on GPUs](https://m-sp.org/downloads/phd_thesis.pdf)**.
+PhD thesis, Tokyo Institute of Technology, 2019.
 
-[#](#ohiwa2019) A. Ohiwa, H. Haga. **[Design and Implementation of Multi Agent Simulation Library MasCUDA for Parallel Processing with GPU](https://dl.acm.org/doi/abs/10.1145/3362752.3362770)**. In Proceedings of the 2nd International Conference on Electronics and Electrical Engineering Technology (EEET), 2019.
-
+<a class="paper" name="ohiwa2019" href="#ohiwa2019">#</a>
+A. Ohiwa, H. Haga.
+**[Design and Implementation of Multi Agent Simulation Library MasCUDA for Parallel Processing with GPU](https://dl.acm.org/doi/abs/10.1145/3362752.3362770)**.
+In Proceedings of the 2nd International Conference on Electronics and Electrical Engineering Technology (EEET), 2019.
 <span class="badge badge-dark">Paywall</span>
 
-[#](#daloze2018) B. Daloze, A. Tal, S. Marr, H. Mössenböck, E. Petrank. **[Parallelization of Dynamic Languages: Synchronizing Built-in Collections](https://ssw.jku.at/General/Staff/Daloze/thread-safe-collections.pdf)**. In Proceedings of the Conference on Object-Oriented Programming, Systems, Languages, and Applications (OOPSLA), 2018.
-
+<a class="paper" name="daloze2018" href="#daloze2018">#</a>
+B. Daloze, A. Tal, S. Marr, H. Mössenböck, E. Petrank.
+**[Parallelization of Dynamic Languages: Synchronizing Built-in Collections](https://ssw.jku.at/General/Staff/Daloze/thread-safe-collections.pdf)**.
+In Proceedings of the Conference on Object-Oriented Programming, Systems, Languages, and Applications (OOPSLA), 2018.
 <span class="badge badge-warning">TruffleRuby</span>
 
-[#](#springer2017) M. Sprinter, P. Wauligmann, H. Masuhara. **[Modular Array-Based GPU Computing in a Dynamically-Typed Language](https://m-sp.org/downloads/array2017.pdf)**. In Proceedings of the 4th International Workshop on Libraries, Languages, and Compilers for Array Programming (ARRAY), 2017.
+<a class="paper" name="springer2017" href="#springer2017">#</a>
+M. Sprinter, P. Wauligmann, H. Masuhara.
+**[Modular Array-Based GPU Computing in a Dynamically-Typed Language](https://m-sp.org/downloads/array2017.pdf)**.
+In Proceedings of the 4th International Workshop on Libraries, Languages, and Compilers for Array Programming (ARRAY), 2017.
 
-[#](#springer2016) M. Springer, H. Masuhara. **[Object Support in an Array-Based GPGPU Extension for Ruby](https://m-sp.org/downloads/array16.pdf)**. In Proceedings of the 3rd International Workshop on Libraries, Languages, and Compilers for Array Programming (ARRAY), 2016.
+<a class="paper" name="springer2016" href="#springer2016">#</a>
+M. Springer, H. Masuhara.
+**[Object Support in an Array-Based GPGPU Extension for Ruby](https://m-sp.org/downloads/array16.pdf)**.
+In Proceedings of the 3rd International Workshop on Libraries, Languages, and Compilers for Array Programming (ARRAY), 2016.
 
-[#](#daloze2016) B. Daloze, S. Marr, D. Bonetta, H. Mössenböck. **[Efficient and Thread-Safe Objects for Dynamically-Typed Languages](https://ssw.jku.at/General/Staff/Daloze/thread-safe-objects.pdf)**. In Proceedings of the Conference on Object-Oriented Programming, Systems, Languages, and Applications (OOPSLA), 2016.
-
+<a class="paper" name="daloze2016" href="#daloze2016">#</a>
+B. Daloze, S. Marr, D. Bonetta, H. Mössenböck.
+**[Efficient and Thread-Safe Objects for Dynamically-Typed Languages](https://ssw.jku.at/General/Staff/Daloze/thread-safe-objects.pdf)**.
+In Proceedings of the Conference on Object-Oriented Programming, Systems, Languages, and Applications (OOPSLA), 2016.
 <span class="badge badge-warning">TruffleRuby</span>
 
-[#](#alcazarzapien2015) J. Alcázar Zapién. **[Debugging Parallel Programs Using Fork Handlers](https://modprobe.files.wordpress.com/2015/09/jalcazar_pmam20151.pdf)**. In Proceedings of the Sixth International Workshop on Programming Models and Applications for Multicores and Manycores (PMAM), 2015.
-
+<a class="paper" name="alcazarzapien2015" href="#alcazarzapien2015">#</a>
+J. Alcázar Zapién.
+**[Debugging Parallel Programs Using Fork Handlers](https://modprobe.files.wordpress.com/2015/09/jalcazar_pmam20151.pdf)**.
+In Proceedings of the Sixth International Workshop on Programming Models and Applications for Multicores and Manycores (PMAM), 2015.
 <span class="badge badge-danger">MRI</span>
 
-[#](#ding2015) C. Ding, B. Gernhardt, P. Li, M. Hertz. **[Safe Parallel Programming in an Interpreted Language](http://polaris.cs.uiuc.edu/hpsl/abstracts/a7-ding.pdf)**. In Proceedings of the First Workshop on the High Performance Scripting Languages, 2015.
-
+<a class="paper" name="ding2015" href="#ding2015">#</a>
+C. Ding, B. Gernhardt, P. Li, M. Hertz.
+**[Safe Parallel Programming in an Interpreted Language](http://polaris.cs.uiuc.edu/hpsl/abstracts/a7-ding.pdf)**.
+In Proceedings of the First Workshop on the High Performance Scripting Languages, 2015.
 <span class="badge badge-danger">MRI</span>
 
-[#](#lu2014) L. Lu, W. Ji, M. L. Scott. **[Dynamic Enforcement of Determinism in a Parallel Scripting Language](https://www.cs.rochester.edu/u/scott/papers/2014_PLDI_DPR.pdf)**. In Proceedings of the 35th Conference on Programming Language Design and Implementation (PLDI), 2014\. ([source code](https://github.com/RB-DPR/RB-DPR))
-
+<a class="paper" name="lu2014" href="#lu2014">#</a>
+L. Lu, W. Ji, M. L. Scott.
+**[Dynamic Enforcement of Determinism in a Parallel Scripting Language](https://www.cs.rochester.edu/u/scott/papers/2014_PLDI_DPR.pdf)**.
+In Proceedings of the 35th Conference on Programming Language Design and Implementation (PLDI), 2014. ([source code](https://github.com/RB-DPR/RB-DPR))
 <span class="badge badge-info">JRuby</span>
 
-[#](#odaira2014) R. Odaira, J. G. Castanos, H. Tomari. **[Eliminating Global Interpreter Locks in Ruby Through Hardware Transactional Memory](https://researcher.watson.ibm.com/researcher/files/jp-ODAIRA/PPoPP2014_RubyGILHTM.pdf)**. In Proceedings of the 19th Symposium on Principles and Practice of Parallel Programming (PPoPP), 2014.
-
+<a class="paper" name="odaira2014" href="#odaira2014">#</a>
+R. Odaira, J. G. Castanos, H. Tomari.
+**[Eliminating Global Interpreter Locks in Ruby Through Hardware Transactional Memory](https://researcher.watson.ibm.com/researcher/files/jp-ODAIRA/PPoPP2014_RubyGILHTM.pdf)**.
+In Proceedings of the 19th Symposium on Principles and Practice of Parallel Programming (PPoPP), 2014.
 <span class="badge badge-danger">MRI</span>
 
-[#](#ji2013) W. Ji, L. Lu, M. L. Scott. **[TARDIS: Task-level Access Race Detection by Intersecting Sets](https://wodet.cs.washington.edu/wp-content/uploads/2013/03/wodet2013-final9.pdf)**. In Proceedings of the 4th Workshop on Determinism and Correctness in Parallel Programming (WoDet), 2013.
-
+<a class="paper" name="ji2013" href="#ji2013">#</a>
+W. Ji, L. Lu, M. L. Scott.
+**[TARDIS: Task-level Access Race Detection by Intersecting Sets](https://wodet.cs.washington.edu/wp-content/uploads/2013/03/wodet2013-final9.pdf)**.
+In Proceedings of the 4th Workshop on Determinism and Correctness in Parallel Programming (WoDet), 2013.
 <span class="badge badge-info">JRuby</span>
 
-[#](#masuhara2012) H. Masuhara, Y. Nishiguchi. **[A Data-Parallel Extension to Ruby for GPGPU - Toward a Framework for Implementing Domain-Specific Optimizations](https://dl.acm.org/doi/abs/10.1145/2237887.2237888)**. In Proceedings of the 9th ECOOP Workshop on Reflection, AOP, and Meta-Data for Software Evolution, 2012.
-
+<a class="paper" name="masuhara2012" href="#masuhara2012">#</a>
+H. Masuhara, Y. Nishiguchi.
+**[A Data-Parallel Extension to Ruby for GPGPU - Toward a Framework for Implementing Domain-Specific Optimizations](https://dl.acm.org/doi/abs/10.1145/2237887.2237888)**.
+In Proceedings of the 9th ECOOP Workshop on Reflection, AOP, and Meta-Data for Software Evolution, 2012.
 <span class="badge badge-dark">Paywall</span>
 
-[#](#nakagawa2012) H. Nakagawa, K. Sasada. **[Design and Implementation of Efficient Interprocess Transfer and Sharing Mechanism for Ruby Objects](https://ipsj.ixsq.nii.ac.jp/ej/index.php?action=pages_view_main&active_action=repository_action_common_download&item_id=83710&item_no=1&attribute_id=1&file_no=1&page_id=13&block_id=8)**. In the IPSJ Journal of Programming (PRO), 2012\. _In Japanese_.
-
+<a class="paper" name="nakagawa2012" href="#nakagawa2012">#</a>
+H. Nakagawa, K. Sasada.
+**[Design and Implementation of Efficient Interprocess Transfer and Sharing Mechanism for Ruby Objects](https://ipsj.ixsq.nii.ac.jp/ej/index.php?action=pages_view_main&active_action=repository_action_common_download&item_id=83710&item_no=1&attribute_id=1&file_no=1&page_id=13&block_id=8)**.
+In the IPSJ Journal of Programming (PRO), 2012. *In Japanese*.
 <span class="badge badge-danger">MRI</span>
-
 <!-- link is flaky -->
 
- [#](#sasada2012) K. Sasada, S. Urabe, Y. Matsumoto, K Hiraki. **[Parallel Processing on Multiple Virtual Machine for Ruby](https://www.atdot.net/~ko1/activities/sasada_mvm_paper.pdf)**. In the IPSJ Journal of Programming (PRO), 2012\. _In Japanese_.
-
+<a class="paper" name="sasada2012" href="#sasada2012">#</a>
+K. Sasada, S. Urabe, Y. Matsumoto, K Hiraki.
+**[Parallel Processing on Multiple Virtual Machine for Ruby](https://www.atdot.net/~ko1/activities/sasada_mvm_paper.pdf)**.
+In the IPSJ Journal of Programming (PRO), 2012. *In Japanese*.
 <span class="badge badge-danger">MRI</span>
 
-[#](#sasada2011) K. Sasada. **[The Improvement of Thread Implementation for Ruby Interpreter](https://www.atdot.net/~ko1/activities/prosym2011-thread_kaizen_paper.pdf)**. In the IPSJ Programming Symposium, 2011\. _In Japanese_.
-
+<a class="paper" name="sasada2011" href="#sasada2011">#</a>
+K. Sasada.
+**[The Improvement of Thread Implementation for Ruby Interpreter](https://www.atdot.net/~ko1/activities/prosym2011-thread_kaizen_paper.pdf)**.
+In the IPSJ Programming Symposium, 2011. *In Japanese*.
 <span class="badge badge-danger">MRI</span>
 
-[#](#sillito2008) J. Sillito. **[Stage: Exploring Erlang Style Concurrency in Ruby](https://dl.acm.org/doi/abs/10.1145/1370082.1370092)**. In Proceedings of the 1st International Workshop on Multicore Software Engineering, 2008.
-
+<a class="paper" name="sillito2008" href="#sillito2008">#</a>
+J. Sillito.
+**[Stage: Exploring Erlang Style Concurrency in Ruby](https://dl.acm.org/doi/abs/10.1145/1370082.1370092)**.
+In Proceedings of the 1st International Workshop on Multicore Software Engineering, 2008.
 <span class="badge badge-dark">Paywall</span>
 
-[#](#sasada2007) K. Sasada, Y. Matsumoto, A. Maeda, M. Namiki. **[An Implementation of Parallel Threads for YARV: Yet Another RubyVM](https://www.atdot.net/~ko1/activities/yarv2007thread.pdf)**. In the IPSJ Journal of Programming (PRO), 2007\. _In Japanese_.
-
+<a class="paper" name="sasada2007" href="#sasada2007">#</a>
+K. Sasada, Y. Matsumoto, A. Maeda, M. Namiki.
+**[An Implementation of Parallel Threads for YARV: Yet Another RubyVM](https://www.atdot.net/~ko1/activities/yarv2007thread.pdf)**.
+In the IPSJ Journal of Programming (PRO), 2007. *In Japanese*.
 <span class="badge badge-danger">MRI</span>
 
-# Type Systems
+### Type Systems
 
-[#](#guria2021) S. N. Guria, J. S. Foster, D. Van Horn. **[RbSyn: Type- and Effect-Guided Program Synthesis](https://arxiv.org/pdf/2102.13183.pdf)**. In Proceedings of the 42nd ACM SIGPLAN Conference on Programming Language Design and Implementation (PLDI), 2021.
+<a class="paper" name="guria2021" href="#guria2021">#</a>
+S. N. Guria, J. S. Foster, D. Van Horn.
+**[RbSyn: Type- and Effect-Guided Program Synthesis](https://arxiv.org/pdf/2102.13183.pdf)**.
+In Proceedings of the 42nd ACM SIGPLAN Conference on Programming Language Design and Implementation (PLDI), 2021.
 
-[#](#kazerounian2019) M. Kazerounian, S. N. Guria, N. Vazou, J. S. Foster, D. Van Horn. **[Type-level Computations for Ruby Libraries](https://arxiv.org/pdf/1904.03521.pdf)**. In Proceedings of the 40th ACM SIGPLAN Conference on Programming Language Design and Implementation (PLDI), 2019.
+<a class="paper" name="kazerounian2019" href="#kazerounian2019">#</a>
+M. Kazerounian, S. N. Guria, N. Vazou, J. S. Foster, D. Van Horn.
+**[Type-level Computations for Ruby Libraries](https://arxiv.org/pdf/1904.03521.pdf)**.
+In Proceedings of the 40th ACM SIGPLAN Conference on Programming Language Design and Implementation (PLDI), 2019.
 
-[#](#kazerounian2018) M. Kazerounian, N. Vazou, A. Bourgerie, J. S. Foster, E. Torlak. **[Refinement Types for Ruby](https://arxiv.org/pdf/1711.09281.pdf)**. In Proceedings of the 19th International Conference on Verification, Model Checking, and Abstract Interpretation (VMCAI), 2018.
+<a class="paper" name="kazerounian2018" href="#kazerounian2018">#</a>
+M. Kazerounian, N. Vazou, A. Bourgerie, J. S. Foster, E. Torlak.
+**[Refinement Types for Ruby](https://arxiv.org/pdf/1711.09281.pdf)**.
+In Proceedings of the 19th International Conference on Verification, Model Checking, and Abstract Interpretation (VMCAI), 2018.
 
-[#](#ren2016) B. M. Ren, J. S. Foster. **[Just-in-Time Static Type Checking for Dynamic Languages](http://www.cs.tufts.edu/~jfoster/papers/pldi16.pdf)**. In Proceedings of the 37th Conference on Programming Language Design and Implementation (PLDI), 2016.
+<a class="paper" name="ren2016" href="#ren2016">#</a>
+B. M. Ren, J. S. Foster.
+**[Just-in-Time Static Type Checking for Dynamic Languages](http://www.cs.tufts.edu/~jfoster/papers/pldi16.pdf)**.
+In Proceedings of the 37th Conference on Programming Language Design and Implementation (PLDI), 2016.
 
-[#](#ren2013) B. M. Ren, J. Toman, T. S. Strickland, J. S. Foster. **[The Ruby Type Checker](http://www.cs.tufts.edu/~jfoster/papers/oops13.pdf)**. In Proceedings of the 28th Symposium on Applied Computing (SAC), 2013.
+<a class="paper" name="ren2013" href="#ren2013">#</a>
+B. M. Ren, J. Toman, T. S. Strickland, J. S. Foster.
+**[The Ruby Type Checker](http://www.cs.tufts.edu/~jfoster/papers/oops13.pdf)**.
+In Proceedings of the 28th Symposium on Applied Computing (SAC), 2013.
 
-[#](#an2011) J. An, A. Chaudhuri, J. S. Foster, M. Hicks. **[Dynamic Inference of Static Types for Ruby](http://www.cs.tufts.edu/~jfoster/papers/popl11.pdf)**. In Proceedings of the 38th ACM Symposium on Principles of Programming Languages (POPL), 2011.
+<a class="paper" name="an2011" href="#an2011">#</a>
+J. An, A. Chaudhuri, J. S. Foster, M. Hicks.
+**[Dynamic Inference of Static Types for Ruby](http://www.cs.tufts.edu/~jfoster/papers/popl11.pdf)**.
+In Proceedings of the 38th ACM Symposium on Principles of Programming Languages (POPL), 2011.
 
-[#](#edgar2011) M. J. Edgar. **[Static Analysis for Ruby in the Presence of Gradual Typing](https://digitalcommons.dartmouth.edu/cgi/viewcontent.cgi?article=1071&context=senior_theses)**. Bachelor's thesis, 2011.
+<a class="paper" name="edgar2011" href="#edgar2011">#</a>
+M. J. Edgar.
+**[Static Analysis for Ruby in the Presence of Gradual Typing](https://digitalcommons.dartmouth.edu/cgi/viewcontent.cgi?article=1071&context=senior_theses)**.
+Bachelor's thesis, 2011.
 
-[#](#furr2009b) M. Furr, J. An, J. S. Foster, M. Hicks. **[Static Typing for Ruby on Rails](http://www.cs.umd.edu/projects/PL/druby/papers/drails-ase09.pdf)**. In Proceedings of the 24th Annual ACM Symposium on Applied Computing, 2009.
+<a class="paper" name="furr2009b" href="#furr2009b">#</a>
+M. Furr, J. An, J. S. Foster, M. Hicks.
+**[Static Typing for Ruby on Rails](http://www.cs.umd.edu/projects/PL/druby/papers/drails-ase09.pdf)**.
+In Proceedings of the 24th Annual ACM Symposium on Applied Computing, 2009.
 
-[#](#furr2009a) M. Furr, J. An, J. S. Foster. **[Work In Progress: an Empirical Study of Static Typing in Ruby](http://www.cs.umd.edu/projects/PL/druby/papers/druby-pilot-plateau09.pdf)**. In Proceedings of the PLATEAU Workshop on Evaluation and Usability of Programming Languages and Tools, 2009.
+<a class="paper" name="furr2009a" href="#furr2009a">#</a>
+M. Furr, J. An, J. S. Foster.
+**[Work In Progress: an Empirical Study of Static Typing in Ruby](http://www.cs.umd.edu/projects/PL/druby/papers/druby-pilot-plateau09.pdf)**.
+In Proceedings of the PLATEAU Workshop on Evaluation and Usability of Programming Languages and Tools, 2009.
 
-[#](#daly2009) M. Daly, V. Sazawal, J. S. Foster. **[Profile-Guided Static Typing for Dynamic Scripting Languages](http://www.cs.umd.edu/projects/PL/druby/papers/druby-oopsla09.pdf)**. In Proceedings of the Conference on Object-Oriented Programming, Systems, Languages, and Applications (OOPSLA), 2009.
+<a class="paper" name="daly2009" href="#daly2009">#</a>
+M. Daly, V. Sazawal, J. S. Foster.
+**[Profile-Guided Static Typing for Dynamic Scripting Languages](http://www.cs.umd.edu/projects/PL/druby/papers/druby-oopsla09.pdf)**.
+In Proceedings of the Conference on Object-Oriented Programming, Systems, Languages, and Applications (OOPSLA), 2009.
 
-[#](#an2009) J. An, A. Chaudhuri, J. S. Foster. **[Static Type Inference for Ruby](http://www.cs.umd.edu/projects/PL/druby/papers/druby-oops09.pdf)**. In Proceedings of the 24th IEEE/ACM International Conference on Automated Software Engineering, 2009.
+<a class="paper" name="an2009" href="#an2009">#</a>
+J. An, A. Chaudhuri, J. S. Foster.
+**[Static Type Inference for Ruby](http://www.cs.umd.edu/projects/PL/druby/papers/druby-oops09.pdf)**.
+In Proceedings of the 24th IEEE/ACM International Conference on Automated Software Engineering, 2009.
 
-[#](#madsen2007) M. Madsen, P. Sørensen, K. Kristensen. **[Ecstatic - Type Inference for Ruby Using the Cartesian Product Algorithm](https://projekter.aau.dk/projekter/files/61071016/1181807983.pdf)**. Master's thesis, Aalborg University, 2007.
+<a class="paper" name="madsen2007" href="#madsen2007">#</a>
+M. Madsen, P. Sørensen, K. Kristensen.
+**[Ecstatic - Type Inference for Ruby Using the Cartesian Product Algorithm](https://projekter.aau.dk/projekter/files/61071016/1181807983.pdf)**.
+Master's thesis, Aalborg University, 2007.
 
-# Garbage Collection
+### Garbage Collection
 
-[#](#powers2019) B. Powers, D. Tench, E. D. Berger, A. McGregor. **[Mesh: Compacting Memory Management for C/C++ Applications](https://arxiv.org/pdf/1902.04738.pdf)**. In Proceedings of the 40th ACM SIGPLAN Conference on Programming Language Design and Implementation (PLDI), 2019.
+<a class="paper" name="powers2019" href="#powers2019">#</a>
+B. Powers, D. Tench, E. D. Berger, A. McGregor.
+**[Mesh: Compacting Memory Management for C/C++ Applications](https://arxiv.org/pdf/1902.04738.pdf)**.
+In Proceedings of the 40th ACM SIGPLAN Conference on Programming Language Design and Implementation (PLDI), 2019.
 
-# Tooling
+### Tooling
 
-[#](#gaikwad2018) S. Gaikwad, A. Nisbet, M. Luján. **[Performance Analysis for Languages Hosted on the Truffle Framework](https://dl.acm.org/doi/10.1145/3237009.3237019)**. In Proceedings of the 15th International Conference on Managed Languages and Runtimes (MANLANG), 2018.
-
+<a class="paper" name="gaikwad2018" href="#gaikwad2018">#</a>
+S. Gaikwad, A. Nisbet, M. Luján.
+**[Performance Analysis for Languages Hosted on the Truffle Framework](https://dl.acm.org/doi/10.1145/3237009.3237019)**.
+In Proceedings of the 15th International Conference on Managed Languages and Runtimes (MANLANG), 2018.
 <span class="badge badge-warning">TruffleRuby</span>
-
 <span class="badge badge-dark">Paywall</span>
 
-[#](#kreindl2018) J. Kreindl, M. Rigger, H. Mössenböck. **[Debugging Native Extensions of Dynamic Languages](https://arxiv.org/pdf/1808.00823.pdf)**. In Proceedings of 15th International Conference on Managed Languages & Runtimes (ManLang), 2018.
-
+<a class="paper" name="kreindl2018" href="#kreindl2018">#</a>
+J. Kreindl, M. Rigger, H. Mössenböck.
+**[Debugging Native Extensions of Dynamic Languages](https://arxiv.org/pdf/1808.00823.pdf)**.
+In Proceedings of 15th International Conference on Managed Languages & Runtimes (ManLang), 2018.
 <span class="badge badge-warning">TruffleRuby</span>
 
-[#](#vandevanter2018) M. Van De Vanter, C. Seaton, M. Haupt, C. Humer, T. Würthinger. **[Fast, Flexible, Polyglot Instrumentation Support for Debuggers and other Tools](https://arxiv.org/pdf/1803.10201v1.pdf)**. In The Art, Science, and Engineering of Programming, Vol. 2, No. 3, 2018.
-
+<a class="paper" name="vandevanter2018" href="#vandevanter2018">#</a>
+M. Van De Vanter, C. Seaton, M. Haupt, C. Humer, T. Würthinger.
+**[Fast, Flexible, Polyglot Instrumentation Support for Debuggers and other Tools](https://arxiv.org/pdf/1803.10201v1.pdf)**.
+In The Art, Science, and Engineering of Programming, Vol. 2, No. 3, 2018.
 <span class="badge badge-warning">TruffleRuby</span>
 
-[#](#miranda2016) S. Miranda, E. Rodrigues Jr, M. T. Valente, R. Terra. **[Architecture Conformance Checking in Dynamically Typed Languages](http://www.sergiohenriquemiranda.com.br/publications/2016_jot.pdf)**. In the Journal of Object Technology (JOT), 2016\. <!-- there's two regional conference papers in 2015 from the same authors, but I don't know the conference - I'm assuming the same content went into this journal paper and I'm including only this one -->
+<a class="paper" name="miranda2016" href="#miranda2016">#</a>
+S. Miranda, E. Rodrigues Jr, M. T. Valente, R. Terra.
+**[Architecture Conformance Checking in Dynamically Typed Languages](http://www.sergiohenriquemiranda.com.br/publications/2016_jot.pdf)**.
+In the Journal of Object Technology (JOT), 2016.
+<!-- there's two regional conference papers in 2015 from the same authors, but I don't know the conference - I'm assuming the same content went into this journal paper and I'm including only this one -->
 
-[#](#savrunyeniceri2015) G. Savrun-Yeniçeri, M. L. Van de Vanter, P. Larsen, S. Brunthaler. **[An Efficient and Generic Event-based Profiler Framework for Dynamic Languages](https://dl.acm.org/doi/abs/10.1145/2807426.2807435)**. In Proceedings of the Principles and Practices of Programming on the Java Platform (PPPJ), 2015.
-
+<a class="paper" name="savrunyeniceri2015" href="#savrunyeniceri2015">#</a>
+G. Savrun-Yeniçeri, M. L. Van de Vanter, P. Larsen, S. Brunthaler.
+**[An Efficient and Generic Event-based Profiler Framework for Dynamic Languages](https://dl.acm.org/doi/abs/10.1145/2807426.2807435)**.
+In Proceedings of the Principles and Practices of Programming on the Java Platform (PPPJ), 2015.
 <span class="badge badge-warning">TruffleRuby</span>
-
 <span class="badge badge-dark">Paywall</span>
 
-[#](#seaton2014) C. Seaton, M. L. Van De Vanter, M. Haupt. **[Debugging at Full Speed](https://www.lifl.fr/dyla14/papers/dyla14-3-Debugging_at_Full_Speed.pdf)**. In Proceedings of the 8th Workshop on Dynamic Languages and Applications (DYLA), 2014\. ([source code](https://web.archive.org/web/20150117042919/https://lafo.ssw.uni-linz.ac.at/truffle/debugging/dyla14-debugging-artifact-0557a4f756d4.tar.gz))
-
+<a class="paper" name="seaton2014" href="#seaton2014">#</a>
+C. Seaton, M. L. Van De Vanter, M. Haupt.
+**[Debugging at Full Speed](https://www.lifl.fr/dyla14/papers/dyla14-3-Debugging_at_Full_Speed.pdf)**.
+In Proceedings of the 8th Workshop on Dynamic Languages and Applications (DYLA), 2014. ([source code](https://web.archive.org/web/20150117042919/https://lafo.ssw.uni-linz.ac.at/truffle/debugging/dyla14-debugging-artifact-0557a4f756d4.tar.gz))
 <span class="badge badge-warning">TruffleRuby</span>
 
-[#](#sunaga2012) T. Sunaga, K. Sasada. **[Design and Implementation of Real-time Profilers for Scripting Languages](https://www.jstage.jst.go.jp/article/jssst/29/4/29_4_95/_pdf)**. In the JSSST Computer Software (2012). _In Japanese_.
-
+<a class="paper" name="sunaga2012" href="#sunaga2012">#</a>
+T. Sunaga, K. Sasada.
+**[Design and Implementation of Real-time Profilers for Scripting Languages](https://www.jstage.jst.go.jp/article/jssst/29/4/29_4_95/_pdf)**.
+In the JSSST Computer Software (2012). *In Japanese*.
 <span class="badge badge-danger">MRI</span>
 
-[#](#nijjar2011) J. Nijjar, T. Bultan. **[Bounded Verification of Ruby on Rails Data Models](https://sites.cs.ucsb.edu/~bultan/publications/issta11.pdf)**. In Proceedings of the 2011 International Symposium on Software Testing and Analysis, 2011.
+<a class="paper" name="nijjar2011" href="#nijjar2011">#</a>
+J. Nijjar, T. Bultan.
+**[Bounded Verification of Ruby on Rails Data Models](https://sites.cs.ucsb.edu/~bultan/publications/issta11.pdf)**.
+In Proceedings of the 2011 International Symposium on Software Testing and Analysis, 2011.
 
-# Software Engineering
+### Software Engineering
 
-[#](#rodrigues2018) E. Rodrigues, R. S. Durelli, R. W. de Bettio, L. Montecchi, R. Terra. **[Refactorings for Replacing Dynamic Instructions with Static Ones: the Case of Ruby](https://dl.acm.org/doi/abs/10.1145/3264637.3264645)**. In Proceedings of the XXII Brazilian Symposium on Programming Languages (SBLP), 2018\. _In Portuguese._
-
+<a class="paper" name="rodrigues2018" href="#rodrigues2018">#</a>
+E. Rodrigues, R. S. Durelli, R. W. de Bettio, L. Montecchi, R. Terra.
+**[Refactorings for Replacing Dynamic Instructions with Static Ones: the Case of Ruby](https://dl.acm.org/doi/abs/10.1145/3264637.3264645)**.
+In Proceedings of the XXII Brazilian Symposium on Programming Languages (SBLP), 2018. *In Portuguese.*
 <span class="badge badge-dark">Paywall</span>
 
-[#](#kikvas2017) R. Kikvas, G. Gousious, M. Dumas, D. Pfahl. **[Structure and Evolution of Package Dependency Networks](https://github.com/amilajack/reading/blob/master/Computer_Science/Structure%20and%20Evolution%20of%20Package%20Dependency%20Networks.pdf)**. In Proceedings of the 14th International Conference on Mining Software Repositories, 2017.
+<a class="paper" name="kikvas2017" href="#kikvas2017">#</a>
+R. Kikvas, G. Gousious, M. Dumas, D. Pfahl.
+**[Structure and Evolution of Package Dependency Networks](https://github.com/amilajack/reading/blob/master/Computer_Science/Structure%20and%20Evolution%20of%20Package%20Dependency%20Networks.pdf)**.
+In Proceedings of the 14th International Conference on Mining Software Repositories, 2017.
 
-[#](#salem2016) P. Salem. **[Practical Programming, Validation and Verification with Finite-State Machines: a Library and its Industrial Application](https://dl.acm.org/doi/abs/10.1145/2889160.2889226)**. In Proceedings of the 38th International Conference on Software Engineering Companion (ICSE), 2016.
-
+<a class="paper" name="salem2016" href="#salem2016">#</a>
+P. Salem.
+**[Practical Programming, Validation and Verification with Finite-State Machines: a Library and its Industrial Application](https://dl.acm.org/doi/abs/10.1145/2889160.2889226)**.
+In Proceedings of the 38th International Conference on Software Engineering Companion (ICSE), 2016.
 <span class="badge badge-dark">Paywall</span>
 
-[#](#strickland2014) T. S. Strickland, B. M. Ren, J. S. Foster. **[Contracts for Domain-Specific Languages in Ruby](http://www.cs.tufts.edu/~jfoster/papers/dls12.pdf)**. In Proceedings of the 10th Symposium on Dynamic Languages (DLS), 2014.
+<a class="paper" name="strickland2014" href="#strickland2014">#</a>
+T. S. Strickland, B. M. Ren, J. S. Foster.
+**[Contracts for Domain-Specific Languages in Ruby](http://www.cs.tufts.edu/~jfoster/papers/dls12.pdf)**.
+In Proceedings of the 10th Symposium on Dynamic Languages (DLS), 2014.
 
-[#](#pasquier2014) T. F. J.-M. Pasquier, J. Bacon, B. Shand. **[FlowR: Aspect Oriented Programming for Information Flow Control in Ruby](https://scholar.harvard.edu/files/tfjmp/files/2014modularity.pdf)**. In Proceedings of the 13th International Conference on Modularity (MODULARITY), 2014.
+<a class="paper" name="pasquier2014" href="#pasquier2014">#</a>
+T. F. J.-M. Pasquier, J. Bacon, B. Shand.
+**[FlowR: Aspect Oriented Programming for Information Flow Control in Ruby](https://scholar.harvard.edu/files/tfjmp/files/2014modularity.pdf)**.
+In Proceedings of the 13th International Conference on Modularity (MODULARITY), 2014.
 
-[#](#pancelet2012) T. Poncelet, L. Vigneron. **[The Phenomenal Gem - Putting Features as a Service on Rails](https://raw.githubusercontent.com/phenomenal/rphenomenal/master/public/The_Phenomenal_Gem_Poncelet_Vigneron_2012.pdf)**. Master's thesis, Université Catholique de Louvain, 2012.
+<a class="paper" name="pancelet2012" href="#pancelet2012">#</a>
+T. Poncelet, L. Vigneron.
+**[The Phenomenal Gem - Putting Features as a Service on Rails](https://raw.githubusercontent.com/phenomenal/rphenomenal/master/public/The_Phenomenal_Gem_Poncelet_Vigneron_2012.pdf)**.
+Master's thesis, Université Catholique de Louvain, 2012.
 
-[#](#loh2012) A. Loh, W. R. Cook, T. van der Storm. **[Managed Data: Modular Strategies for Data Abstraction](https://www.cs.utexas.edu/~wcook/Drafts/2012/ensodata.pdf)**. In Proceedings of _Onward!_, 2012.
+<a class="paper" name="loh2012" href="#loh2012">#</a>
+A. Loh, W. R. Cook, T. van der Storm.
+**[Managed Data: Modular Strategies for Data Abstraction](https://www.cs.utexas.edu/~wcook/Drafts/2012/ensodata.pdf)**.
+In Proceedings of *Onward!*, 2012.
 
-[#](#vanderstorm2012) T. van der Storm, A. Loh, W. R. Cook. **[Object Grammars: Compositional & Bidirectional Mapping Between Text and Graphs](https://www.cs.utexas.edu/~wcook/Drafts/2012/ensogrammars.pdf)**. In Proceedings of the 5th International Conference on Software Language Engineering, 2012.
+<a class="paper" name="vanderstorm2012" href="#vanderstorm2012">#</a>
+T. van der Storm, A. Loh, W. R. Cook.
+**[Object Grammars: Compositional & Bidirectional Mapping Between Text and Graphs](https://www.cs.utexas.edu/~wcook/Drafts/2012/ensogrammars.pdf)**.
+In Proceedings of the 5th International Conference on Software Language Engineering, 2012.
 
-[#](#mairhofer2011) S. Mairhofer, R. Feldt, R. Torkar, S. Poulding. **[Search-Based Software Testing and Test Data Generation for a Dynamic Programming Language](https://arxiv.org/pdf/1804.09232.pdf)**. In Proceedings of the 13th Annual Conference on Genetic and Evolutionary Computation, 2011.
+<a class="paper" name="mairhofer2011" href="#mairhofer2011">#</a>
+S. Mairhofer, R. Feldt, R. Torkar, S. Poulding.
+**[Search-Based Software Testing and Test Data Generation for a Dynamic Programming Language](https://arxiv.org/pdf/1804.09232.pdf)**.
+In Proceedings of the 13th Annual Conference on Genetic and Evolutionary Computation, 2011.
 
-[#](#guenther2010b) S. Günther, M. Fischer. **[Metaprogramming in Ruby - A Pattern Catalog](https://www.hillside.net/plop/2010/papers/ACMVersions/papers/gunther-1.pdf)**. In Proceedings of the 17th Conference on Pattern Languages of Programs, 2010.
+<a class="paper" name="guenther2010b" href="#guenther2010b">#</a>
+S. Günther, M. Fischer.
+**[Metaprogramming in Ruby - A Pattern Catalog](https://www.hillside.net/plop/2010/papers/ACMVersions/papers/gunther-1.pdf)**.
+In Proceedings of the 17th Conference on Pattern Languages of Programs, 2010.
 
-[#](#guenther2010a) S. Günther, T. Cleenewerck. **[Design Principles for Internal Domain-Specific Languages: A Pattern Catalog Illustrated by Ruby](https://www.hillside.net/plop/2010/papers/ACMVersions/papers/gunther-2.pdf)**. In Proceedings of the 17th Conference on Pattern Languages of Programs, 2010.
+<a class="paper" name="guenther2010a" href="#guenther2010a">#</a>
+S. Günther, T. Cleenewerck.
+**[Design Principles for Internal Domain-Specific Languages: A Pattern Catalog Illustrated by Ruby](https://www.hillside.net/plop/2010/papers/ACMVersions/papers/gunther-2.pdf)**.
+In Proceedings of the 17th Conference on Pattern Languages of Programs, 2010.
 
-[#](#guenther2010c) S. Günther, S. Sunkle. **[Dynamically Adaptable Software Product Lines using Ruby Metaprogramming](https://www.se.cs.uni-saarland.de/apel/FOSD2010/80-guenther.pdf)**. In Proceedings of the 2nd International Workshop on Feature-Oriented Software Development, 2010.
+<a class="paper" name="guenther2010c" href="#guenther2010c">#</a>
+S. Günther, S. Sunkle.
+**[Dynamically Adaptable Software Product Lines using Ruby Metaprogramming](https://www.se.cs.uni-saarland.de/apel/FOSD2010/80-guenther.pdf)**.
+In Proceedings of the 2nd International Workshop on Feature-Oriented Software Development, 2010.
 
-[#](#guenther2009) S. Günther, S. Sunkle. **[Feature-Oriented Programming with Ruby](https://dl.acm.org/doi/abs/10.1145/1629716.1629721)**. Technical report, 2009.
+<a class="paper" name="guenther2009" href="#guenther2009">#</a>
+S. Günther, S. Sunkle.
+**[Feature-Oriented Programming with Ruby](https://dl.acm.org/doi/abs/10.1145/1629716.1629721)**.
+Technical report, 2009.
 
-[#](#guenther2009b) S. Günther, S. Sunkle. **[Enabling Feature-Oriented Programming in Ruby](https://www.inf.ovgu.de/inf_media/downloads/forschung/technical_reports_und_preprints/2009/2009_internet/TechReport16-p-2226.pdf)**. In Proceedings of the 1st International Workshop on Feature-Oriented Software Development, 2009.
-
+<a class="paper" name="guenther2009b" href="#guenther2009b">#</a>
+S. Günther, S. Sunkle.
+**[Enabling Feature-Oriented Programming in Ruby](https://www.inf.ovgu.de/inf_media/downloads/forschung/technical_reports_und_preprints/2009/2009_internet/TechReport16-p-2226.pdf)**.
+In Proceedings of the 1st International Workshop on Feature-Oriented Software Development, 2009.
 <span class="badge badge-dark">Paywall</span>
 
-[#](#oritz08) A. Oritz. **[Language Design and Implementation Using Ruby and the Interpreter Pattern](http://34.212.143.74/publicaciones/sif.pdf)**. In Proceedings of the 39th SIGCSE Technical Symposium on Computer Science Education, 2008.
+<a class="paper" name="oritz08" href="#oritz08">#</a>
+A. Oritz.
+**[Language Design and Implementation Using Ruby and the Interpreter Pattern](http://34.212.143.74/publicaciones/sif.pdf)**.
+In Proceedings of the 39th SIGCSE Technical Symposium on Computer Science Education, 2008.
 
-[#](#geebelen2008) K. Geebelen, S. Michiels, W. Joosen. **[Dynamic Reconfiguration Using Template Based Web Service Composition](https://dl.acm.org/doi/abs/10.1145/1462802.1462811)**. In Proceedings of the 3rd Workshop on Middleware for Service Oriented Computing, 2008.
-
+<a class="paper" name="geebelen2008" href="#geebelen2008">#</a>
+K. Geebelen, S. Michiels, W. Joosen.
+**[Dynamic Reconfiguration Using Template Based Web Service Composition](https://dl.acm.org/doi/abs/10.1145/1462802.1462811)**.
+In Proceedings of the 3rd Workshop on Middleware for Service Oriented Computing, 2008.
 <span class="badge badge-dark">Paywall</span>
 
-[#](#sheehan07) R. J. Scheehan. **[Teaching Operating Systems With Ruby](https://dl.acm.org/doi/10.1145/1268784.1268798)**. In Proceedings of the 12th Annual SIGCSE Conference on Innovation and Technology in Computer Science Education, 2007.
-
+<a class="paper" name="sheehan07" href="#sheehan07">#</a>
+R. J. Scheehan.
+**[Teaching Operating Systems With Ruby](https://dl.acm.org/doi/10.1145/1268784.1268798)**.
+In Proceedings of the 12th Annual SIGCSE Conference on Innovation and Technology in Computer Science Education, 2007.
 <span class="badge badge-dark">Paywall</span>
 
-# Security
+### Security
 
-[#](#near2016) J. P. Near, D. Jackson. **[Finding Security Bugs in Web Applications using a Catalog of Access Control Patterns](https://dspace.mit.edu/bitstream/handle/1721.1/102281/jnear-icse16.pdf)**. In Proceedings of the 38th International Conference on Software Engineering, 2016.
+<a class="paper" name="near2016" href="#near2016">#</a>
+J. P. Near, D. Jackson.
+**[Finding Security Bugs in Web Applications using a Catalog of Access Control Patterns](https://dspace.mit.edu/bitstream/handle/1721.1/102281/jnear-icse16.pdf)**.
+In Proceedings of the 38th International Conference on Software Engineering, 2016.
 
-[#](#chaudhuri2010) A. Chaudhuri, J. Foster. **[Symbolic Security Analysis of Ruby-on-Rails Web Applications](https://cseweb.ucsd.edu/~dstefan/cse291-winter18/papers/rubyx.pdf)**. In Proceedings of the 17th Conference on Computer and Communications Security, 2010.
+<a class="paper" name="chaudhuri2010" href="#chaudhuri2010">#</a>
+A. Chaudhuri, J. Foster.
+**[Symbolic Security Analysis of Ruby-on-Rails Web Applications](https://cseweb.ucsd.edu/~dstefan/cse291-winter18/papers/rubyx.pdf)**.
+In Proceedings of the 17th Conference on Computer and Communications Security, 2010.
 
-# Computer Vision
+### Computer Vision
 
-[#](#wedekind2012) J. Wedekind. **[Efficient Implementations of Machine Vision Algorithms using a Dynamically Typed Programming Language](https://s3-eu-west-1.amazonaws.com/pfigshare-u-files/143003/thesis_wedekind.pdf)**. PhD thesis, 2012.
+<a class="paper" name="wedekind2012" href="#wedekind2012">#</a>
+J. Wedekind.
+**[Efficient Implementations of Machine Vision Algorithms using a Dynamically Typed Programming Language](https://s3-eu-west-1.amazonaws.com/pfigshare-u-files/143003/thesis_wedekind.pdf)**.
+PhD thesis, 2012.
 
-# Bioinformatics
+### Bioinformatics
 
-[#](#smith2013) R. Smith, R. Williamson, D. Ventura, J. T. Prince. **[Rubabel: wrapping open Babel with Ruby](https://jcheminf.biomedcentral.com/track/pdf/10.1186/1758-2946-5-35.pdf)**. Journal of Cheminformatics, 5(1), 35, 2013.
+<a class="paper" name="smith2013" href="#smith2013">#</a>
+R. Smith, R. Williamson, D. Ventura, J. T. Prince.
+**[Rubabel: wrapping open Babel with Ruby](https://jcheminf.biomedcentral.com/track/pdf/10.1186/1758-2946-5-35.pdf)**.
+Journal of Cheminformatics, 5(1), 35, 2013.
 
-[#](#goto2010) N. Goto, P. Prins, M. Nakao, R. Bonnal, J. Aerts, T. Katayama. **[Bioruby: bioinformatics software for the Ruby programming language](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2951089/pdf/btq475.pdf)**. Bioinformatics, 26(20):2617–9, Oct 2010.
+<a class="paper" name="goto2010" href="#goto2010">#</a>
+N. Goto, P. Prins, M. Nakao, R. Bonnal, J. Aerts, T. Katayama.
+**[Bioruby: bioinformatics software for the Ruby programming language](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2951089/pdf/btq475.pdf)**.
+Bioinformatics, 26(20):2617–9, Oct 2010.
 
-# Robotics
+### Robotics
 
-[#](#roman2007) B. Roman, C. Scholin, S. Jensen, E. Massion, R. Marin III, C. Preston, D. Greenfield, W. Jones, K. Wheeler. **[Controlling a Robotic Marine Environmental Sampler with the Ruby Scripting Language](https://journals.sagepub.com/doi/pdf/10.1016/j.jala.2006.07.013)**. JALA - Journal of the Association for Laboratory Automation, 12(1), 56-61, 2007.
+<a class="paper" name="roman2007" href="#roman2007">#</a>
+B. Roman, C. Scholin, S. Jensen, E. Massion, R. Marin III, C. Preston, D. Greenfield, W. Jones, K. Wheeler.
+**[Controlling a Robotic Marine Environmental Sampler with the Ruby Scripting Language](https://journals.sagepub.com/doi/pdf/10.1016/j.jala.2006.07.013)**.
+JALA - Journal of the Association for Laboratory Automation, 12(1), 56-61, 2007.
 
-# Electronic Design Automation
+### Electronic Design Automation
+<a class="paper" name="lelann2020" href="#lelann">#</a>
+J-C. Le Lann, H. Badier, F. Kermarrec. **[Towards a Hardware DSL Ecosystem : RubyRTL and friends](https://arxiv.org/abs/2004.09858)**. OSDA - Open Source Design Automation workshop, collocated with DATE Conference, Design Automation and Test in Europe, 2020.
 
-[#](#lelann2020) J-C. Le Lann, H. Badier, F. Kermarrec. **[Towards a Hardware DSL Ecosystem : RubyRTL and friends](https://arxiv.org/abs/2004.09858)**. OSDA - Open Source Design Automation workshop, collocated with DATE Conference, Design Automation and Test in Europe, 2020.
+### Modeling and Simulation
 
-# Modeling and Simulation
-
-[#](#cuadrado2006) J. S. Cuadrado, J. G. Molina, M. M. Tortosa. **[RubyTL: A Practical, Extensible Transformation Language](https://link.springer.com/chapter/10.1007/11787044_13)**. Model Driven Architecture - Foundations and Applications, 2006.
-
+<a class="paper" name="cuadrado2006" href="#cuadrado2006">#</a>
+J. S. Cuadrado, J. G. Molina, M. M. Tortosa.
+**[RubyTL: A Practical, Extensible Transformation Language](https://link.springer.com/chapter/10.1007/11787044_13)**.
+Model Driven Architecture - Foundations and Applications, 2006.
 <span class="badge badge-dark">Paywall</span>
 
 ## Standards
 
-[#](#iso) IPA Ruby Standardization WG. **[ISO/IEC 30170:2012 Information technology -- Programming languages -- Ruby](https://www.iso.org/standard/59579.html)**. The Ruby ISO standard, 2012.
-
+<a class="paper" name="iso" href="#iso">#</a>
+IPA Ruby Standardization WG.
+**[ISO/IEC 30170:2012 Information technology — Programming languages — Ruby](https://www.iso.org/standard/59579.html)**.
+The Ruby ISO standard, 2012.
 <span class="badge badge-dark">Paywall</span>

--- a/index.md
+++ b/index.md
@@ -3,612 +3,388 @@ layout: default
 title: The Ruby Bibliography
 ---
 
-### Virtual Machines and Compilers
+# Virtual Machines and Compilers
 
-<a class="paper" name="daloze2019" href="#daloze2019">#</a>
-B. Daloze.
-**[Thread-Safe and Efficient Data Representations in Dynamically-Typed Languages](https://eregon.me/blog/assets/research/thesis-thread-safe-data-representations-in-dynamic-languages.pdf)**.
-PhD thesis, Johannes Kepler University Linz, 2019.
+[#](#daloze2019) B. Daloze. **[Thread-Safe and Efficient Data Representations in Dynamically-Typed Languages](https://eregon.me/blog/assets/research/thesis-thread-safe-data-representations-in-dynamic-languages.pdf)**. PhD thesis, Johannes Kepler University Linz, 2019.
+
 <span class="badge badge-warning">TruffleRuby</span>
 
-<a class="paper" name="mosaner2019" href="#mosaner2019">#</a>
-R. Mosaner, D. Leopoldseder, M. Rigger, R. Schatz, H. Mössenböck.
-**[Supporting On-Stack Replacement in Unstructured Languages by Loop Reconstruction and Extraction](https://arxiv.org/pdf/1909.08815.pdf)**.
-In Proceedings of the 16th International Conference on Managed Programming Languages and Runtimes (MPLR), 2019.
+[#](#mosaner2019) R. Mosaner, D. Leopoldseder, M. Rigger, R. Schatz, H. Mössenböck. **[Supporting On-Stack Replacement in Unstructured Languages by Loop Reconstruction and Extraction](https://arxiv.org/pdf/1909.08815.pdf)**. In Proceedings of the 16th International Conference on Managed Programming Languages and Runtimes (MPLR), 2019.
+
 <span class="badge badge-warning">TruffleRuby</span>
 
-<a class="paper" name="sasada2019" href="#sasada2019">#</a>
-K. Sasada.
-**[Gradual Write-Barrier Insertion into a Ruby interpreter](https://www.atdot.net/~ko1/activities/rgengc_ismm.pdf)**.
-In Proceedings of the International Symposium on Memory Management (ISMM), 2019.
+[#](#sasada2019) K. Sasada. **[Gradual Write-Barrier Insertion into a Ruby interpreter](https://www.atdot.net/~ko1/activities/rgengc_ismm.pdf)**. In Proceedings of the International Symposium on Memory Management (ISMM), 2019.
+
 <span class="badge badge-danger">MRI</span>
 
-<a class="paper" name="sugiyama2018" href="#sugiyama2018">#</a>
-K. Sugiyama, K. Sasada, M. J. Dürst.
-**[Dynamic Extension of the Ruby Virtual Machine Stack](https://ipsj.ixsq.nii.ac.jp/ej/index.php?active_action=repository_view_main_item_detail&page_id=13&block_id=8&item_id=191427&item_no=1)**.
-In the IPSJ Journal of Programming (PRO), 2018. *In Japanese*.
+[#](#sugiyama2018) K. Sugiyama, K. Sasada, M. J. Dürst. **[Dynamic Extension of the Ruby Virtual Machine Stack](https://ipsj.ixsq.nii.ac.jp/ej/index.php?active_action=repository_view_main_item_detail&page_id=13&block_id=8&item_id=191427&item_no=1)**. In the IPSJ Journal of Programming (PRO), 2018\. _In Japanese_.
+
 <span class="badge badge-danger">MRI</span>
+
 <!-- link is flaky -->
 
-<a class="paper" name="menard2018" href="#menard2018">#</a>
-K. Menard, C. Seaton, B. Daloze.
-**[Specializing Ropes for Ruby](https://chrisseaton.com/truffleruby/ropes-manlang.pdf)**.
-In Proceedings of 15th International Conference on Managed Languages & Runtimes (ManLang), 2018.
+ [#](#menard2018) K. Menard, C. Seaton, B. Daloze. **[Specializing Ropes for Ruby](https://chrisseaton.com/truffleruby/ropes-manlang.pdf)**. In Proceedings of 15th International Conference on Managed Languages & Runtimes (ManLang), 2018.
+
 <span class="badge badge-warning">TruffleRuby</span>
 
-<a class="paper" name="grimmer2018" href="#grimmer2018">#</a>
-M. Grimmer, R. Schatz, C. Seaton, T. Würthinger, M. Luján.
-**[Cross-Language Interoperability in a Multi-Language Runtime](https://chrisseaton.com/truffleruby/cross-language-interop.pdf)**.
-In ACM Transactions on Programming Languages and Systems (TOPLAS), Vol. 40, No. 2, 2018.
+[#](#grimmer2018) M. Grimmer, R. Schatz, C. Seaton, T. Würthinger, M. Luján. **[Cross-Language Interoperability in a Multi-Language Runtime](https://chrisseaton.com/truffleruby/cross-language-interop.pdf)**. In ACM Transactions on Programming Languages and Systems (TOPLAS), Vol. 40, No. 2, 2018.
+
 <span class="badge badge-warning">TruffleRuby</span>
 
-<a class="paper" name="yang2017" href="#yang2017">#</a>
-B. Yang, J. Kim, S. Moon.
-**[Exceptionalization: A Java VM Optimization for Non-Java Languages](https://dl.acm.org/doi/10.1145/3046681)**.
-In ACM Transactions on Architecture and Code Optimization (TACO), volume 14, issue 1, 2017.
+[#](#yang2017) B. Yang, J. Kim, S. Moon. **[Exceptionalization: A Java VM Optimization for Non-Java Languages](https://dl.acm.org/doi/10.1145/3046681)**. In ACM Transactions on Architecture and Code Optimization (TACO), volume 14, issue 1, 2017.
+
 <span class="badge badge-info">JRuby</span>
+
 <span class="badge badge-dark">Paywall</span>
 
-<a class="paper" name="xu2017" href="#xu2017">#</a>
-S. Xu, D. Bremner, D. Heidinga.
-**[Fusing Method Handle Graphs for Efficient Dynamic JVM Language Implementations](https://xushijie.github.io/papers/vmil17.pdf)**.
-In Proceedings of the 9th ACM SIGPLAN International Workshop on Virtual Machines and Intermediate Languages (VMIL), 2017.
+[#](#xu2017) S. Xu, D. Bremner, D. Heidinga. **[Fusing Method Handle Graphs for Efficient Dynamic JVM Language Implementations](https://xushijie.github.io/papers/vmil17.pdf)**. In Proceedings of the 9th ACM SIGPLAN International Workshop on Virtual Machines and Intermediate Languages (VMIL), 2017.
+
 <span class="badge badge-info">JRuby</span>
 
-<a class="paper" name="wuerthinger2017" href="#wuerthinger2017">#</a>
-T. Würthinger, C. Wimmer, C. Humer, A. Wöss, L. Stadler, C. Seaton, G. Duboscq, D. Simon, M. Grimmer.
-**[Practical Partial Evaluation for High-Performance Dynamic Language Runtimes](https://chrisseaton.com/rubytruffle/pldi17-truffle/pldi17-truffle.pdf)**.
-In Proceedings of the 38th Conference on Programming Language Design and Implementation (PLDI), 2017.
+[#](#wuerthinger2017) T. Würthinger, C. Wimmer, C. Humer, A. Wöss, L. Stadler, C. Seaton, G. Duboscq, D. Simon, M. Grimmer. **[Practical Partial Evaluation for High-Performance Dynamic Language Runtimes](https://chrisseaton.com/rubytruffle/pldi17-truffle/pldi17-truffle.pdf)**. In Proceedings of the 38th Conference on Programming Language Design and Implementation (PLDI), 2017.
+
 <span class="badge badge-warning">TruffleRuby</span>
 
-<a class="paper" name="georgiou2017" href="#georgiou2017">#</a>
-S. Georgiou, M. Kechagia, D. Spinellis.
-**[Analyzing Programming Languages' Energy Consumption: An Empirical Study](https://stefanos1316.github.io/my_curriculum_vitae/GKS17.pdf)**.
-In Proceedings of the 21st Pan-Hellenic Conference on Informatics (PCI), 2017.
+[#](#georgiou2017) S. Georgiou, M. Kechagia, D. Spinellis. **[Analyzing Programming Languages' Energy Consumption: An Empirical Study](https://stefanos1316.github.io/my_curriculum_vitae/GKS17.pdf)**. In Proceedings of the 21st Pan-Hellenic Conference on Informatics (PCI), 2017.
 
-<a class="paper" name="marr2016" href="#marr2016">#</a>
-S. Marr, B. Daloze, H. Mössenböck.
-**[Cross-Language Compiler Benchmarking - Are We Fast Yet?](https://stefan-marr.de/downloads/dls16-marr-et-al-cross-language-compiler-benchmarking-are-we-fast-yet.pdf)** In Proceedings of the 12th Dynamic Languages Symposium (DLS), 2016.
-<span class="badge badge-warning">TruffleRuby</span> <span class="badge badge-info">JRuby</span> <span class="badge badge-secondary">Rubinius</span> <span class="badge badge-danger">MRI</span>
+[#](#marr2016) S. Marr, B. Daloze, H. Mössenböck. **[Cross-Language Compiler Benchmarking - Are We Fast Yet?](https://stefan-marr.de/downloads/dls16-marr-et-al-cross-language-compiler-benchmarking-are-we-fast-yet.pdf)** In Proceedings of the 12th Dynamic Languages Symposium (DLS), 2016.
 
-<a class="paper" name="seaton2016" href="#seaton2016">#</a>
-C. Seaton.
-**[AST Specialisation and Partial Evaluation for Easy High-Performance Metaprogramming](https://chrisseaton.com/rubytruffle/meta16/meta16-ruby.pdf)**.
-In Proceedings of the 1st Workshop on Meta-Programming Techniques and Reflection (META), 2016.
 <span class="badge badge-warning">TruffleRuby</span>
 
-<a class="paper" name="xu2016" href="#xu2016">#</a>
-S. Xu, D. Bremner, D. Heidinga.
-**[MHDeS: Deduplicating Method Handle Graphs for Efficient Dynamic JVM Language Implementations](https://xushijie.github.io/papers/deduplication.pdf)**.
-In Proceedings of the 11th Workshop on Implementation, Compilation, Optimization of Object-Oriented Languages, Programs and Systems (ICOOOLPS), 2016.
 <span class="badge badge-info">JRuby</span>
 
-<a class="paper" name="ide2015a" href="#ide2015a">#</a>
-M. Ide.
-**[Study on Method-based and Trace-based Just-in-time Compilation for Scripting Languages](https://ynu.repo.nii.ac.jp/?action=repository_action_common_download&item_id=4714&item_no=1&attribute_id=20&file_no=1)**.
-PhD thesis, Yokohama National University, 2015.
+<span class="badge badge-secondary">Rubinius</span>
+
 <span class="badge badge-danger">MRI</span>
 
-<a class="paper" name="ide2015b" href="#ide2015b">#</a>
-M. Ide, K. Kuramitsu.
-**[A Trace-based Just-in-time Compiler for Ruby](https://kuramitsulab.github.io/paper/rujit.pdf)**.
-In Journal of Information Processing Society of Japan, Transactions on Programming, 2015. *In Japanese*.
+[#](#seaton2016) C. Seaton. **[AST Specialisation and Partial Evaluation for Easy High-Performance Metaprogramming](https://chrisseaton.com/rubytruffle/meta16/meta16-ruby.pdf)**. In Proceedings of the 1st Workshop on Meta-Programming Techniques and Reflection (META), 2016.
+
+<span class="badge badge-warning">TruffleRuby</span>
+
+[#](#xu2016) S. Xu, D. Bremner, D. Heidinga. **[MHDeS: Deduplicating Method Handle Graphs for Efficient Dynamic JVM Language Implementations](https://xushijie.github.io/papers/deduplication.pdf)**. In Proceedings of the 11th Workshop on Implementation, Compilation, Optimization of Object-Oriented Languages, Programs and Systems (ICOOOLPS), 2016.
+
+<span class="badge badge-info">JRuby</span>
+
+[#](#ide2015a) M. Ide. **[Study on Method-based and Trace-based Just-in-time Compilation for Scripting Languages](https://ynu.repo.nii.ac.jp/?action=repository_action_common_download&item_id=4714&item_no=1&attribute_id=20&file_no=1)**. PhD thesis, Yokohama National University, 2015.
+
 <span class="badge badge-danger">MRI</span>
 
-<a class="paper" name="tanaka2015" href="#tanaka2015">#</a>
-K. Tanaka, A. D. Nagumanthri, Y. Matsumoto.
-**[mruby – Rapid Software Development for Embedded Systems](https://www.researchgate.net/profile/Aviansh-Nagumanthri/publication/282816987_mruby_-_Rapid_Software_Development_for_Embedded_Systems/links/561f03e308ae50795aff64d0/mruby-Rapid-Software-Development-for-Embedded-Systems.pdf)**.
-In Proceedings of the 15th International Conference on Computational Science and its Applications (ICCSA), 2015.
+[#](#ide2015b) M. Ide, K. Kuramitsu. **[A Trace-based Just-in-time Compiler for Ruby](https://kuramitsulab.github.io/paper/rujit.pdf)**. In Journal of Information Processing Society of Japan, Transactions on Programming, 2015\. _In Japanese_.
+
+<span class="badge badge-danger">MRI</span>
+
+[#](#tanaka2015) K. Tanaka, A. D. Nagumanthri, Y. Matsumoto. **[mruby – Rapid Software Development for Embedded Systems](https://www.researchgate.net/profile/Aviansh-Nagumanthri/publication/282816987_mruby_-_Rapid_Software_Development_for_Embedded_Systems/links/561f03e308ae50795aff64d0/mruby-Rapid-Software-Development-for-Embedded-Systems.pdf)**. In Proceedings of the 15th International Conference on Computational Science and its Applications (ICCSA), 2015.
+
 <span class="badge badge-success">mruby</span>
 
-<a class="paper" name="xu2015" href="#xu2015">#</a>
-S. Xu, D. Bremner, D. Heidinga.
-**[Mining Method Handle Graphs for Efficient Dynamic JVM Languages](https://xushijie.github.io/papers/mh_mining.pdf)**.
-In ACM proceedings 12th Conference on Principles and Practices of Programming on the Java Platform (PPPJ), 2015.
+[#](#xu2015) S. Xu, D. Bremner, D. Heidinga. **[Mining Method Handle Graphs for Efficient Dynamic JVM Languages](https://xushijie.github.io/papers/mh_mining.pdf)**. In ACM proceedings 12th Conference on Principles and Practices of Programming on the Java Platform (PPPJ), 2015.
+
 <span class="badge badge-info">JRuby</span>
 
-<a class="paper" name="viering2015" href="#viering2015">#</a>
-M. Viering.
-**[An Efficient Runtime System for Reactive Programming](http://mviering.de/reactiveruby.pdf)**.
-Master thesis, Technische Universität Darmstadt, 2015.
+[#](#viering2015) M. Viering. **[An Efficient Runtime System for Reactive Programming](http://mviering.de/reactiveruby.pdf)**. Master thesis, Technische Universität Darmstadt, 2015.
+
 <span class="badge badge-warning">TruffleRuby</span>
 
-<a class="paper" name="seaton2015" href="#seaton2015">#</a>
-C. Seaton.
-**[Specialising Dynamic Techniques for Implementing the Ruby Programming Language](https://chrisseaton.com/phd/specialising-ruby.pdf)**.
-PhD thesis, University of Manchester, 2015.
+[#](#seaton2015) C. Seaton. **[Specialising Dynamic Techniques for Implementing the Ruby Programming Language](https://chrisseaton.com/phd/specialising-ruby.pdf)**. PhD thesis, University of Manchester, 2015.
+
 <span class="badge badge-warning">TruffleRuby</span>
 
-<a class="paper" name="grimmer2015b" href="#grimmer2015b">#</a>
-M. Grimmer, C. Seaton, R. Schatz, T. Würthinger, H. Mössenböck.
-**[High-Performance Cross-Language Interoperability in a Multi-Language Runtime](https://chrisseaton.com/rubytruffle/dls15-interop/dls15-interop.pdf)**.
-In Proceedings of the 11th Dynamic Languages Symposium (DLS), 2015.
+[#](#grimmer2015b) M. Grimmer, C. Seaton, R. Schatz, T. Würthinger, H. Mössenböck. **[High-Performance Cross-Language Interoperability in a Multi-Language Runtime](https://chrisseaton.com/rubytruffle/dls15-interop/dls15-interop.pdf)**. In Proceedings of the 11th Dynamic Languages Symposium (DLS), 2015.
+
 <span class="badge badge-warning">TruffleRuby</span>
 
-<a class="paper" name="niephaus2015" href="#niephaus2015">#</a>
-F. Niephaus, M. Springer, T. Felgentreff, T. Pape, R. Hirschfeld.
-**[Call-target-specific Method Arguments](https://raw.githubusercontent.com/HPI-SWA-Lab/TargetSpecific-ICOOOLPS/gh-pages/call_target_specific_method_arguments.pdf)**.
-In Proceedings of the 10th Implementation, Compilation, Optimization of Object-Oriented Languages, Programs and Systems Workshop (ICOOOLPS), 2015.
+[#](#niephaus2015) F. Niephaus, M. Springer, T. Felgentreff, T. Pape, R. Hirschfeld. **[Call-target-specific Method Arguments](https://raw.githubusercontent.com/HPI-SWA-Lab/TargetSpecific-ICOOOLPS/gh-pages/call_target_specific_method_arguments.pdf)**. In Proceedings of the 10th Implementation, Compilation, Optimization of Object-Oriented Languages, Programs and Systems Workshop (ICOOOLPS), 2015.
+
 <span class="badge badge-warning">TruffleRuby</span>
 
-<a class="paper" name="daloze2015" href="#daloze2015">#</a>
-B. Daloze, C. Seaton, D. Bonetta, H. Mössenböck.
-**[Techniques and Applications for Guest-Language Safepoints](https://chrisseaton.com/rubytruffle/icooolps15-safepoints/safepoints.pdf)**.
-In Proceedings of the 10th Implementation, Compilation, Optimization of Object-Oriented Languages, Programs and Systems Workshop (ICOOOLPS), 2015.
+[#](#daloze2015) B. Daloze, C. Seaton, D. Bonetta, H. Mössenböck. **[Techniques and Applications for Guest-Language Safepoints](https://chrisseaton.com/rubytruffle/icooolps15-safepoints/safepoints.pdf)**. In Proceedings of the 10th Implementation, Compilation, Optimization of Object-Oriented Languages, Programs and Systems Workshop (ICOOOLPS), 2015.
+
 <span class="badge badge-warning">TruffleRuby</span>
 
-<a class="paper" name="marr2015" href="#marr2015">#</a>
-S. Marr, C. Seaton, S. Ducasse.
-**[Zero-Overhead Metaprogramming: Reflection and Metaobject Protocols Fast and without Compromises](https://chrisseaton.com/rubytruffle/pldi15-metaprogramming/pldi15-marr-et-al-zero-overhead-metaprogramming.pdf)**.
-In Proceedings of the 36th Conference on Programming Language Design and Implementation (PLDI), 2015.
+[#](#marr2015) S. Marr, C. Seaton, S. Ducasse. **[Zero-Overhead Metaprogramming: Reflection and Metaobject Protocols Fast and without Compromises](https://chrisseaton.com/rubytruffle/pldi15-metaprogramming/pldi15-marr-et-al-zero-overhead-metaprogramming.pdf)**. In Proceedings of the 36th Conference on Programming Language Design and Implementation (PLDI), 2015.
+
 <span class="badge badge-warning">TruffleRuby</span>
 
-<a class="paper" name="grimmer2015a" href="#grimmer2015a">#</a>
-M. Grimmer, C. Seaton, T. Würthinger, H. Mössenböck.
-**[Dynamically Composing Languages in a Modular Way: Supporting C Extensions for Dynamic Languages](https://chrisseaton.com/rubytruffle/modularity15/rubyextensions.pdf)**.
-In Proceedings of the 14th International Conference on Modularity, 2015.
+[#](#grimmer2015a) M. Grimmer, C. Seaton, T. Würthinger, H. Mössenböck. **[Dynamically Composing Languages in a Modular Way: Supporting C Extensions for Dynamic Languages](https://chrisseaton.com/rubytruffle/modularity15/rubyextensions.pdf)**. In Proceedings of the 14th International Conference on Modularity, 2015.
+
 <span class="badge badge-warning">TruffleRuby</span>
 
-<a class="paper" name="woess2014" href="#woess2014">#</a>
-A. Wöß, C. Wirth, D. Bonetta, C. Seaton, C. Humer, H. Mössenböck.
-**[An Object Storage Model for the Truffle Language Implementation Framework](https://chrisseaton.com/rubytruffle/pppj14-om/pppj14-om.pdf)**.
-In Proceedings of the International Conference on Principles and Practices of Programming on the Java Platform (PPPJ), 2014.
+[#](#woess2014) A. Wöß, C. Wirth, D. Bonetta, C. Seaton, C. Humer, H. Mössenböck. **[An Object Storage Model for the Truffle Language Implementation Framework](https://chrisseaton.com/rubytruffle/pppj14-om/pppj14-om.pdf)**. In Proceedings of the International Conference on Principles and Practices of Programming on the Java Platform (PPPJ), 2014.
+
 <span class="badge badge-warning">TruffleRuby</span>
 
-<a class="paper" name="sarimbekov2013" href="#sarimbekov2013">#</a>
-A. Sarimbekov, A. Podzimek, L. Bulej, Y. Zheng, N. Ricci, W. Binder.
-**[Characteristics of Dynamic JVM Languages](http://design.cs.iastate.edu/vmil/2013/papers/p05-Sarimbekov.pdf)**.
-In Proceedings of the 7th Workshop on Virtual Machines and Intermediate Languages (VMIL), 2013.
+[#](#sarimbekov2013) A. Sarimbekov, A. Podzimek, L. Bulej, Y. Zheng, N. Ricci, W. Binder. **[Characteristics of Dynamic JVM Languages](http://design.cs.iastate.edu/vmil/2013/papers/p05-Sarimbekov.pdf)**. In Proceedings of the 7th Workshop on Virtual Machines and Intermediate Languages (VMIL), 2013.
+
 <span class="badge badge-info">JRuby</span>
 
-<a class="paper" name="hang2013" href="#hang2013">#</a>
-<a name="talk-talk">W. Hang Li, D. R. White, J. Singer.
-**[JVM-Hosted Languages: They Talk the Talk, but do they Walk the Walk?](http://www.dcs.gla.ac.uk/~jsinger/pdfs/pppj13.pdf)** In Proceedings of the International Conference on Principles and Practices of Programming on the Java Platform (PPPJ), 2013.
+[#](#hang2013) [W. Hang Li, D. R. White, J. Singer. _**_]()**[JVM-Hosted Languages: They Talk the Talk, but do they Walk the Walk?](http://www.dcs.gla.ac.uk/~jsinger/pdfs/pppj13.pdf)** In Proceedings of the International Conference on Principles and Practices of Programming on the Java Platform (PPPJ), 2013.
+
 <span class="badge badge-info">JRuby</span>
 
-<a class="paper" name="springer2013" href="#springer2013">#</a>
-M. Springer.
-**[Inter-language Collaboration in an Object-oriented Virtual Machine](http://matthiasspringer.de/downloads/BP2012H1_intra-language_collaboration.pdf)**.
-Bachelor's thesis, Hasso-Plattner-Institute, 2013.
+[#](#springer2013) M. Springer. **[Inter-language Collaboration in an Object-oriented Virtual Machine](http://matthiasspringer.de/downloads/BP2012H1_intra-language_collaboration.pdf)**. Bachelor's thesis, Hasso-Plattner-Institute, 2013.
+
 <span class="badge badge-primary">MagLev</span>
 
-<a class="paper" name="castanos2012" href="#castanos2012">#</a>
-J. Castanos, D. Edelsohn, K. Ishizaki, P. Nagpurkar, T. Nakatani, T. Ogasawara, P. Wu.
-**[On the Benefits and Pitfalls of Extending a Statically Typed Language JIT Compiler for Dynamic Scripting Languages](https://researcher.watson.ibm.com/researcher/files/us-pengwu/oopsla12-final-dsl.pdf)**.
-In Proceedings of the 20th Conference on Object-Oriented Programming, Systems, Languages, and Applications (OOPSLA), 2012.
-<span class="badge badge-info">JRuby</span> <span class="badge badge-secondary">Rubinius</span>
+[#](#castanos2012) J. Castanos, D. Edelsohn, K. Ishizaki, P. Nagpurkar, T. Nakatani, T. Ogasawara, P. Wu. **[On the Benefits and Pitfalls of Extending a Statically Typed Language JIT Compiler for Dynamic Scripting Languages](https://researcher.watson.ibm.com/researcher/files/us-pengwu/oopsla12-final-dsl.pdf)**. In Proceedings of the 20th Conference on Object-Oriented Programming, Systems, Languages, and Applications (OOPSLA), 2012.
 
-<a class="paper" name="shiba2012" href="#shiba2012">#</a>
-S. Shiba, K. Sasada, K. Hiraki.
-**[CastOff: A Compiler for Ruby Implemented as a Library](https://ipsj.ixsq.nii.ac.jp/ej/?action=pages_view_main&active_action=repository_view_main_item_detail&item_id=83510&item_no=1&page_id=13&block_id=8)**.
-In Journal of Information Processing Society of Japan, Transactions on Programming, 2012. *In Japanese*.
-<span class="badge badge-danger">MRI</span>
-<!-- link is flaky -->
-
-<a class="paper" name="shiba2011" href="#shiba2011">#</a>
-S. Shiba, K. Sasada, S. Urabe, Y. Matsumoto, M. Inaba, K. Hiraki.
-**[A Practical AOT Compiler for Ruby](https://ipsj.ixsq.nii.ac.jp/ej/?action=pages_view_main&active_action=repository_view_main_item_detail&item_id=73661&item_no=1&page_id=13&block_id=8)**.
-In Journal of Information Processing Society of Japan, Transactions on Programming, 2011. *In Japanese*.
-<span class="badge badge-danger">MRI</span>
-<!-- link is flaky -->
-
-<a class="paper" name="zakirov2010" href="#zakirov2010">#</a>
-S. Zakirov, S. Chiba, E. Shibayama.
-**[How to Select Superinstructions for Ruby](https://www.researchgate.net/publication/239436707_How_to_Select_Superinstructions_for_Ruby)**.
-In Journal of Information Processing Society of Japan, Transactions on Programming, 2010.
-<span class="badge badge-danger">MRI</span>
-
-<a class="paper" name="zakirov2010b" href="#zakirov2010b">#</a>
-S. Zakirov, S. Chiba, E. Shibayama.
-**[Optimizing Dynamic Dispatch with Fine-grained State Tracking](https://dl.acm.org/doi/10.1145/1869631.1869634)**.
-In Proceedings of the Dynamic Language Symposium, 2010.
-<span class="badge badge-dark">Paywall</span>
-
-<a class="paper" name="furr2009" href="#furr2009">#</a>
-M. Furr, J. An, J. S. Foster, M. Hicks.
-**[The Ruby Intermediate Language](http://www.cs.umd.edu/projects/PL/druby/papers/druby-dls09.pdf)**.
-In Proceedings of the Dynamic Language Symposium, 2009.
-
-<a class="paper" name="sasada2009" href="#sasada2009">#</a>
-K. Sasada.
-**[Ricsin: A System for “C Mix-in to Ruby”](https://www.atdot.net/~ko1/activities/ricsin2009.pdf)**.
-In Proceedings of the IPSJ Programming Workshop, 2009. *In Japanese*.
-<span class="badge badge-danger">MRI</span>
-
-<a class="paper" name="sasada2008" href="#sasada2008">#</a>
-K. Sasada.
-**[A Lightweight Representation of Floting-Point Numbers on Ruby Interpreter](https://www.atdot.net/~ko1/activities/rubyfp2008.pdf)**.
-In Proceedings of PPL, 2008. *In Japanese*.
-<span class="badge badge-danger">MRI</span>
-
-<a class="paper" name="prokopski2008" href="#prokopski2008">#</a>
-G. B. Prokopski, C. Verbrugge.
-**[Analyzing the Performance of Code-Copying Virtual Machines](https://dl.acm.org/doi/10.1145/1449764.1449796)**.
-In Proceedings of the 23rd Conference on Object-Oriented Programming, Systems, Languages, and Applications (OOPSLA), 2008.
-<span class="badge badge-danger">MRI</span>
-<span class="badge badge-dark">Paywall</span>
-
-<a class="paper" name="kelly2008" href="#kelly2008">#</a>
-W. Kelly, J. Gough.
-**[Ruby.NET: a Ruby Compiler for the Common Language Infrastructure](http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.294.2678)**.
-In Proceedings of the 31st Australasian Conference on Computer Science, 2008.
-
-<a class="paper" name="sasada2005b" href="#sasada2005b">#</a>
-K. Sasada, Y. Matsumoto, A. Maeda, M. Namiki.
-**[YARV: Yet Another RubyVM The Implementation and Evaluation](https://www.atdot.net/~ko1/activities/yarv2005vm.pdf)**.
-In the IPSJ Journal of Programming (PRO), 2005. *In Japanese*.
-<span class="badge badge-danger">MRI</span>
-
-<a class="paper" name="sasada2005" href="#sasada2005">#</a>
-K. Sasada.
-**[YARV: Yet Another RubyVM: Innovating the Ruby Interpreter](https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.482.9851&rep=rep1&type=pdf)**.
-In Proceedings of the 20th Conference on Object-Oriented Programming, Systems, Languages, and Applications (OOPSLA), 2005.
-<span class="badge badge-danger">MRI</span>
-
-### Parallelism and Concurrency
-
-<a class="paper" name="springer2019" href="#springer2019">#</a>
-M. Springer.
-**[Memory-Efficient Object-Oriented Programming on GPUs](https://m-sp.org/downloads/phd_thesis.pdf)**.
-PhD thesis, Tokyo Institute of Technology, 2019.
-
-<a class="paper" name="ohiwa2019" href="#ohiwa2019">#</a>
-A. Ohiwa, H. Haga.
-**[Design and Implementation of Multi Agent Simulation Library MasCUDA for Parallel Processing with GPU](https://dl.acm.org/doi/abs/10.1145/3362752.3362770)**.
-In Proceedings of the 2nd International Conference on Electronics and Electrical Engineering Technology (EEET), 2019.
-<span class="badge badge-dark">Paywall</span>
-
-<a class="paper" name="daloze2018" href="#daloze2018">#</a>
-B. Daloze, A. Tal, S. Marr, H. Mössenböck, E. Petrank.
-**[Parallelization of Dynamic Languages: Synchronizing Built-in Collections](https://ssw.jku.at/General/Staff/Daloze/thread-safe-collections.pdf)**.
-In Proceedings of the Conference on Object-Oriented Programming, Systems, Languages, and Applications (OOPSLA), 2018.
-<span class="badge badge-warning">TruffleRuby</span>
-
-<a class="paper" name="springer2017" href="#springer2017">#</a>
-M. Sprinter, P. Wauligmann, H. Masuhara.
-**[Modular Array-Based GPU Computing in a Dynamically-Typed Language](https://m-sp.org/downloads/array2017.pdf)**.
-In Proceedings of the 4th International Workshop on Libraries, Languages, and Compilers for Array Programming (ARRAY), 2017.
-
-<a class="paper" name="springer2016" href="#springer2016">#</a>
-M. Springer, H. Masuhara.
-**[Object Support in an Array-Based GPGPU Extension for Ruby](https://m-sp.org/downloads/array16.pdf)**.
-In Proceedings of the 3rd International Workshop on Libraries, Languages, and Compilers for Array Programming (ARRAY), 2016.
-
-<a class="paper" name="daloze2016" href="#daloze2016">#</a>
-B. Daloze, S. Marr, D. Bonetta, H. Mössenböck.
-**[Efficient and Thread-Safe Objects for Dynamically-Typed Languages](https://ssw.jku.at/General/Staff/Daloze/thread-safe-objects.pdf)**.
-In Proceedings of the Conference on Object-Oriented Programming, Systems, Languages, and Applications (OOPSLA), 2016.
-<span class="badge badge-warning">TruffleRuby</span>
-
-<a class="paper" name="alcazarzapien2015" href="#alcazarzapien2015">#</a>
-J. Alcázar Zapién.
-**[Debugging Parallel Programs Using Fork Handlers](https://modprobe.files.wordpress.com/2015/09/jalcazar_pmam20151.pdf)**.
-In Proceedings of the Sixth International Workshop on Programming Models and Applications for Multicores and Manycores (PMAM), 2015.
-<span class="badge badge-danger">MRI</span>
-
-<a class="paper" name="ding2015" href="#ding2015">#</a>
-C. Ding, B. Gernhardt, P. Li, M. Hertz.
-**[Safe Parallel Programming in an Interpreted Language](http://polaris.cs.uiuc.edu/hpsl/abstracts/a7-ding.pdf)**.
-In Proceedings of the First Workshop on the High Performance Scripting Languages, 2015.
-<span class="badge badge-danger">MRI</span>
-
-<a class="paper" name="lu2014" href="#lu2014">#</a>
-L. Lu, W. Ji, M. L. Scott.
-**[Dynamic Enforcement of Determinism in a Parallel Scripting Language](https://www.cs.rochester.edu/u/scott/papers/2014_PLDI_DPR.pdf)**.
-In Proceedings of the 35th Conference on Programming Language Design and Implementation (PLDI), 2014. ([source code](https://github.com/RB-DPR/RB-DPR))
 <span class="badge badge-info">JRuby</span>
 
-<a class="paper" name="odaira2014" href="#odaira2014">#</a>
-R. Odaira, J. G. Castanos, H. Tomari.
-**[Eliminating Global Interpreter Locks in Ruby Through Hardware Transactional Memory](https://researcher.watson.ibm.com/researcher/files/jp-ODAIRA/PPoPP2014_RubyGILHTM.pdf)**.
-In Proceedings of the 19th Symposium on Principles and Practice of Parallel Programming (PPoPP), 2014.
+<span class="badge badge-secondary">Rubinius</span>
+
+[#](#shiba2012) S. Shiba, K. Sasada, K. Hiraki. **[CastOff: A Compiler for Ruby Implemented as a Library](https://ipsj.ixsq.nii.ac.jp/ej/?action=pages_view_main&active_action=repository_view_main_item_detail&item_id=83510&item_no=1&page_id=13&block_id=8)**. In Journal of Information Processing Society of Japan, Transactions on Programming, 2012\. _In Japanese_.
+
 <span class="badge badge-danger">MRI</span>
 
-<a class="paper" name="ji2013" href="#ji2013">#</a>
-W. Ji, L. Lu, M. L. Scott.
-**[TARDIS: Task-level Access Race Detection by Intersecting Sets](https://wodet.cs.washington.edu/wp-content/uploads/2013/03/wodet2013-final9.pdf)**.
-In Proceedings of the 4th Workshop on Determinism and Correctness in Parallel Programming (WoDet), 2013.
-<span class="badge badge-info">JRuby</span>
-
-<a class="paper" name="masuhara2012" href="#masuhara2012">#</a>
-H. Masuhara, Y. Nishiguchi.
-**[A Data-Parallel Extension to Ruby for GPGPU - Toward a Framework for Implementing Domain-Specific Optimizations](https://dl.acm.org/doi/abs/10.1145/2237887.2237888)**.
-In Proceedings of the 9th ECOOP Workshop on Reflection, AOP, and Meta-Data for Software Evolution, 2012.
-<span class="badge badge-dark">Paywall</span>
-
-<a class="paper" name="nakagawa2012" href="#nakagawa2012">#</a>
-H. Nakagawa, K. Sasada.
-**[Design and Implementation of Efficient Interprocess Transfer and Sharing Mechanism for Ruby Objects](https://ipsj.ixsq.nii.ac.jp/ej/index.php?action=pages_view_main&active_action=repository_action_common_download&item_id=83710&item_no=1&attribute_id=1&file_no=1&page_id=13&block_id=8)**.
-In the IPSJ Journal of Programming (PRO), 2012. *In Japanese*.
-<span class="badge badge-danger">MRI</span>
 <!-- link is flaky -->
 
-<a class="paper" name="sasada2012" href="#sasada2012">#</a>
-K. Sasada, S. Urabe, Y. Matsumoto, K Hiraki.
-**[Parallel Processing on Multiple Virtual Machine for Ruby](https://www.atdot.net/~ko1/activities/sasada_mvm_paper.pdf)**.
-In the IPSJ Journal of Programming (PRO), 2012. *In Japanese*.
+ [#](#shiba2011) S. Shiba, K. Sasada, S. Urabe, Y. Matsumoto, M. Inaba, K. Hiraki. **[A Practical AOT Compiler for Ruby](https://ipsj.ixsq.nii.ac.jp/ej/?action=pages_view_main&active_action=repository_view_main_item_detail&item_id=73661&item_no=1&page_id=13&block_id=8)**. In Journal of Information Processing Society of Japan, Transactions on Programming, 2011\. _In Japanese_.
+
 <span class="badge badge-danger">MRI</span>
 
-<a class="paper" name="sasada2011" href="#sasada2011">#</a>
-K. Sasada.
-**[The Improvement of Thread Implementation for Ruby Interpreter](https://www.atdot.net/~ko1/activities/prosym2011-thread_kaizen_paper.pdf)**.
-In the IPSJ Programming Symposium, 2011. *In Japanese*.
+<!-- link is flaky -->
+
+ [#](#zakirov2010) S. Zakirov, S. Chiba, E. Shibayama. **[How to Select Superinstructions for Ruby](https://www.researchgate.net/publication/239436707_How_to_Select_Superinstructions_for_Ruby)**. In Journal of Information Processing Society of Japan, Transactions on Programming, 2010.
+
 <span class="badge badge-danger">MRI</span>
 
-<a class="paper" name="sillito2008" href="#sillito2008">#</a>
-J. Sillito.
-**[Stage: Exploring Erlang Style Concurrency in Ruby](https://dl.acm.org/doi/abs/10.1145/1370082.1370092)**.
-In Proceedings of the 1st International Workshop on Multicore Software Engineering, 2008.
+[#](#zakirov2010b) S. Zakirov, S. Chiba, E. Shibayama. **[Optimizing Dynamic Dispatch with Fine-grained State Tracking](https://dl.acm.org/doi/10.1145/1869631.1869634)**. In Proceedings of the Dynamic Language Symposium, 2010.
+
 <span class="badge badge-dark">Paywall</span>
 
-<a class="paper" name="sasada2007" href="#sasada2007">#</a>
-K. Sasada, Y. Matsumoto, A. Maeda, M. Namiki.
-**[An Implementation of Parallel Threads for YARV: Yet Another RubyVM](https://www.atdot.net/~ko1/activities/yarv2007thread.pdf)**.
-In the IPSJ Journal of Programming (PRO), 2007. *In Japanese*.
+[#](#furr2009) M. Furr, J. An, J. S. Foster, M. Hicks. **[The Ruby Intermediate Language](http://www.cs.umd.edu/projects/PL/druby/papers/druby-dls09.pdf)**. In Proceedings of the Dynamic Language Symposium, 2009.
+
+[#](#sasada2009) K. Sasada. **[Ricsin: A System for "C Mix-in to Ruby"](https://www.atdot.net/~ko1/activities/ricsin2009.pdf)**. In Proceedings of the IPSJ Programming Workshop, 2009\. _In Japanese_.
+
 <span class="badge badge-danger">MRI</span>
 
-### Type Systems
+[#](#sasada2008) K. Sasada. **[A Lightweight Representation of Floting-Point Numbers on Ruby Interpreter](https://www.atdot.net/~ko1/activities/rubyfp2008.pdf)**. In Proceedings of PPL, 2008\. _In Japanese_.
 
-<a class="paper" name="guria2021" href="#guria2021">#</a>
-S. N. Guria, J. S. Foster, D. Van Horn.
-**[RbSyn: Type- and Effect-Guided Program Synthesis](https://arxiv.org/pdf/2102.13183.pdf)**.
-In Proceedings of the 42nd ACM SIGPLAN Conference on Programming Language Design and Implementation (PLDI), 2021.
-
-<a class="paper" name="kazerounian2019" href="#kazerounian2019">#</a>
-M. Kazerounian, S. N. Guria, N. Vazou, J. S. Foster, D. Van Horn.
-**[Type-level Computations for Ruby Libraries](https://arxiv.org/pdf/1904.03521.pdf)**.
-In Proceedings of the 40th ACM SIGPLAN Conference on Programming Language Design and Implementation (PLDI), 2019.
-
-<a class="paper" name="kazerounian2018" href="#kazerounian2018">#</a>
-M. Kazerounian, N. Vazou, A. Bourgerie, J. S. Foster, E. Torlak.
-**[Refinement Types for Ruby](https://arxiv.org/pdf/1711.09281.pdf)**.
-In Proceedings of the 19th International Conference on Verification, Model Checking, and Abstract Interpretation (VMCAI), 2018.
-
-<a class="paper" name="ren2016" href="#ren2016">#</a>
-B. M. Ren, J. S. Foster.
-**[Just-in-Time Static Type Checking for Dynamic Languages](http://www.cs.tufts.edu/~jfoster/papers/pldi16.pdf)**.
-In Proceedings of the 37th Conference on Programming Language Design and Implementation (PLDI), 2016.
-
-<a class="paper" name="ren2013" href="#ren2013">#</a>
-B. M. Ren, J. Toman, T. S. Strickland, J. S. Foster.
-**[The Ruby Type Checker](http://www.cs.tufts.edu/~jfoster/papers/oops13.pdf)**.
-In Proceedings of the 28th Symposium on Applied Computing (SAC), 2013.
-
-<a class="paper" name="an2011" href="#an2011">#</a>
-J. An, A. Chaudhuri, J. S. Foster, M. Hicks.
-**[Dynamic Inference of Static Types for Ruby](http://www.cs.tufts.edu/~jfoster/papers/popl11.pdf)**.
-In Proceedings of the 38th ACM Symposium on Principles of Programming Languages (POPL), 2011.
-
-<a class="paper" name="edgar2011" href="#edgar2011">#</a>
-M. J. Edgar.
-**[Static Analysis for Ruby in the Presence of Gradual Typing](https://digitalcommons.dartmouth.edu/cgi/viewcontent.cgi?article=1071&context=senior_theses)**.
-Bachelor's thesis, 2011.
-
-<a class="paper" name="furr2009b" href="#furr2009b">#</a>
-M. Furr, J. An, J. S. Foster, M. Hicks.
-**[Static Typing for Ruby on Rails](http://www.cs.umd.edu/projects/PL/druby/papers/drails-ase09.pdf)**.
-In Proceedings of the 24th Annual ACM Symposium on Applied Computing, 2009.
-
-<a class="paper" name="furr2009a" href="#furr2009a">#</a>
-M. Furr, J. An, J. S. Foster.
-**[Work In Progress: an Empirical Study of Static Typing in Ruby](http://www.cs.umd.edu/projects/PL/druby/papers/druby-pilot-plateau09.pdf)**.
-In Proceedings of the PLATEAU Workshop on Evaluation and Usability of Programming Languages and Tools, 2009.
-
-<a class="paper" name="daly2009" href="#daly2009">#</a>
-M. Daly, V. Sazawal, J. S. Foster.
-**[Profile-Guided Static Typing for Dynamic Scripting Languages](http://www.cs.umd.edu/projects/PL/druby/papers/druby-oopsla09.pdf)**.
-In Proceedings of the Conference on Object-Oriented Programming, Systems, Languages, and Applications (OOPSLA), 2009.
-
-<a class="paper" name="an2009" href="#an2009">#</a>
-J. An, A. Chaudhuri, J. S. Foster.
-**[Static Type Inference for Ruby](http://www.cs.umd.edu/projects/PL/druby/papers/druby-oops09.pdf)**.
-In Proceedings of the 24th IEEE/ACM International Conference on Automated Software Engineering, 2009.
-
-<a class="paper" name="madsen2007" href="#madsen2007">#</a>
-M. Madsen, P. Sørensen, K. Kristensen.
-**[Ecstatic - Type Inference for Ruby Using the Cartesian Product Algorithm](https://projekter.aau.dk/projekter/files/61071016/1181807983.pdf)**.
-Master's thesis, Aalborg University, 2007.
-
-### Garbage Collection
-
-<a class="paper" name="powers2019" href="#powers2019">#</a>
-B. Powers, D. Tench, E. D. Berger, A. McGregor.
-**[Mesh: Compacting Memory Management for C/C++ Applications](https://arxiv.org/pdf/1902.04738.pdf)**.
-In Proceedings of the 40th ACM SIGPLAN Conference on Programming Language Design and Implementation (PLDI), 2019.
-
-### Tooling
-
-<a class="paper" name="gaikwad2018" href="#gaikwad2018">#</a>
-S. Gaikwad, A. Nisbet, M. Luján.
-**[Performance Analysis for Languages Hosted on the Truffle Framework](https://dl.acm.org/doi/10.1145/3237009.3237019)**.
-In Proceedings of the 15th International Conference on Managed Languages and Runtimes (MANLANG), 2018.
-<span class="badge badge-warning">TruffleRuby</span>
-<span class="badge badge-dark">Paywall</span>
-
-<a class="paper" name="kreindl2018" href="#kreindl2018">#</a>
-J. Kreindl, M. Rigger, H. Mössenböck.
-**[Debugging Native Extensions of Dynamic Languages](https://arxiv.org/pdf/1808.00823.pdf)**.
-In Proceedings of 15th International Conference on Managed Languages & Runtimes (ManLang), 2018.
-<span class="badge badge-warning">TruffleRuby</span>
-
-<a class="paper" name="vandevanter2018" href="#vandevanter2018">#</a>
-M. Van De Vanter, C. Seaton, M. Haupt, C. Humer, T. Würthinger.
-**[Fast, Flexible, Polyglot Instrumentation Support for Debuggers and other Tools](https://arxiv.org/pdf/1803.10201v1.pdf)**.
-In The Art, Science, and Engineering of Programming, Vol. 2, No. 3, 2018.
-<span class="badge badge-warning">TruffleRuby</span>
-
-<a class="paper" name="miranda2016" href="#miranda2016">#</a>
-S. Miranda, E. Rodrigues Jr, M. T. Valente, R. Terra.
-**[Architecture Conformance Checking in Dynamically Typed Languages](http://www.sergiohenriquemiranda.com.br/publications/2016_jot.pdf)**.
-In the Journal of Object Technology (JOT), 2016.
-<!-- there's two regional conference papers in 2015 from the same authors, but I don't know the conference - I'm assuming the same content went into this journal paper and I'm including only this one -->
-
-<a class="paper" name="savrunyeniceri2015" href="#savrunyeniceri2015">#</a>
-G. Savrun-Yeniçeri, M. L. Van de Vanter, P. Larsen, S. Brunthaler.
-**[An Efficient and Generic Event-based Profiler Framework for Dynamic Languages](https://dl.acm.org/doi/abs/10.1145/2807426.2807435)**.
-In Proceedings of the Principles and Practices of Programming on the Java Platform (PPPJ), 2015.
-<span class="badge badge-warning">TruffleRuby</span>
-<span class="badge badge-dark">Paywall</span>
-
-<a class="paper" name="seaton2014" href="#seaton2014">#</a>
-C. Seaton, M. L. Van De Vanter, M. Haupt.
-**[Debugging at Full Speed](https://www.lifl.fr/dyla14/papers/dyla14-3-Debugging_at_Full_Speed.pdf)**.
-In Proceedings of the 8th Workshop on Dynamic Languages and Applications (DYLA), 2014. ([source code](https://web.archive.org/web/20150117042919/https://lafo.ssw.uni-linz.ac.at/truffle/debugging/dyla14-debugging-artifact-0557a4f756d4.tar.gz))
-<span class="badge badge-warning">TruffleRuby</span>
-
-<a class="paper" name="sunaga2012" href="#sunaga2012">#</a>
-T. Sunaga, K. Sasada.
-**[Design and Implementation of Real-time Profilers for Scripting Languages](https://www.jstage.jst.go.jp/article/jssst/29/4/29_4_95/_pdf)**.
-In the JSSST Computer Software (2012). *In Japanese*.
 <span class="badge badge-danger">MRI</span>
 
-<a class="paper" name="nijjar2011" href="#nijjar2011">#</a>
-J. Nijjar, T. Bultan.
-**[Bounded Verification of Ruby on Rails Data Models](https://sites.cs.ucsb.edu/~bultan/publications/issta11.pdf)**.
-In Proceedings of the 2011 International Symposium on Software Testing and Analysis, 2011.
+[#](#prokopski2008) G. B. Prokopski, C. Verbrugge. **[Analyzing the Performance of Code-Copying Virtual Machines](https://dl.acm.org/doi/10.1145/1449764.1449796)**. In Proceedings of the 23rd Conference on Object-Oriented Programming, Systems, Languages, and Applications (OOPSLA), 2008.
 
-### Software Engineering
+<span class="badge badge-danger">MRI</span>
 
-<a class="paper" name="rodrigues2018" href="#rodrigues2018">#</a>
-E. Rodrigues, R. S. Durelli, R. W. de Bettio, L. Montecchi, R. Terra.
-**[Refactorings for Replacing Dynamic Instructions with Static Ones: the Case of Ruby](https://dl.acm.org/doi/abs/10.1145/3264637.3264645)**.
-In Proceedings of the XXII Brazilian Symposium on Programming Languages (SBLP), 2018. *In Portuguese.*
 <span class="badge badge-dark">Paywall</span>
 
-<a class="paper" name="kikvas2017" href="#kikvas2017">#</a>
-R. Kikvas, G. Gousious, M. Dumas, D. Pfahl.
-**[Structure and Evolution of Package Dependency Networks](https://github.com/amilajack/reading/blob/master/Computer_Science/Structure%20and%20Evolution%20of%20Package%20Dependency%20Networks.pdf)**.
-In Proceedings of the 14th International Conference on Mining Software Repositories, 2017.
+[#](#kelly2008) W. Kelly, J. Gough. **[Ruby.NET: a Ruby Compiler for the Common Language Infrastructure](http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.294.2678)**. In Proceedings of the 31st Australasian Conference on Computer Science, 2008.
 
-<a class="paper" name="salem2016" href="#salem2016">#</a>
-P. Salem.
-**[Practical Programming, Validation and Verification with Finite-State Machines: a Library and its Industrial Application](https://dl.acm.org/doi/abs/10.1145/2889160.2889226)**.
-In Proceedings of the 38th International Conference on Software Engineering Companion (ICSE), 2016.
+[#](#sasada2005b) K. Sasada, Y. Matsumoto, A. Maeda, M. Namiki. **[YARV: Yet Another RubyVM The Implementation and Evaluation](https://www.atdot.net/~ko1/activities/yarv2005vm.pdf)**. In the IPSJ Journal of Programming (PRO), 2005\. _In Japanese_.
+
+<span class="badge badge-danger">MRI</span>
+
+[#](#sasada2005) K. Sasada. **[YARV: Yet Another RubyVM: Innovating the Ruby Interpreter](https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.482.9851&rep=rep1&type=pdf)**. In Proceedings of the 20th Conference on Object-Oriented Programming, Systems, Languages, and Applications (OOPSLA), 2005.
+
+<span class="badge badge-danger">MRI</span>
+
+# Parallelism and Concurrency
+
+[#](#springer2019) M. Springer. **[Memory-Efficient Object-Oriented Programming on GPUs](https://m-sp.org/downloads/phd_thesis.pdf)**. PhD thesis, Tokyo Institute of Technology, 2019.
+
+[#](#ohiwa2019) A. Ohiwa, H. Haga. **[Design and Implementation of Multi Agent Simulation Library MasCUDA for Parallel Processing with GPU](https://dl.acm.org/doi/abs/10.1145/3362752.3362770)**. In Proceedings of the 2nd International Conference on Electronics and Electrical Engineering Technology (EEET), 2019.
+
 <span class="badge badge-dark">Paywall</span>
 
-<a class="paper" name="strickland2014" href="#strickland2014">#</a>
-T. S. Strickland, B. M. Ren, J. S. Foster.
-**[Contracts for Domain-Specific Languages in Ruby](http://www.cs.tufts.edu/~jfoster/papers/dls12.pdf)**.
-In Proceedings of the 10th Symposium on Dynamic Languages (DLS), 2014.
+[#](#daloze2018) B. Daloze, A. Tal, S. Marr, H. Mössenböck, E. Petrank. **[Parallelization of Dynamic Languages: Synchronizing Built-in Collections](https://ssw.jku.at/General/Staff/Daloze/thread-safe-collections.pdf)**. In Proceedings of the Conference on Object-Oriented Programming, Systems, Languages, and Applications (OOPSLA), 2018.
 
-<a class="paper" name="pasquier2014" href="#pasquier2014">#</a>
-T. F. J.-M. Pasquier, J. Bacon, B. Shand.
-**[FlowR: Aspect Oriented Programming for Information Flow Control in Ruby](https://scholar.harvard.edu/files/tfjmp/files/2014modularity.pdf)**.
-In Proceedings of the 13th International Conference on Modularity (MODULARITY), 2014.
+<span class="badge badge-warning">TruffleRuby</span>
 
-<a class="paper" name="pancelet2012" href="#pancelet2012">#</a>
-T. Poncelet, L. Vigneron.
-**[The Phenomenal Gem - Putting Features as a Service on Rails](https://raw.githubusercontent.com/phenomenal/rphenomenal/master/public/The_Phenomenal_Gem_Poncelet_Vigneron_2012.pdf)**.
-Master's thesis, Université Catholique de Louvain, 2012.
+[#](#springer2017) M. Sprinter, P. Wauligmann, H. Masuhara. **[Modular Array-Based GPU Computing in a Dynamically-Typed Language](https://m-sp.org/downloads/array2017.pdf)**. In Proceedings of the 4th International Workshop on Libraries, Languages, and Compilers for Array Programming (ARRAY), 2017.
 
-<a class="paper" name="loh2012" href="#loh2012">#</a>
-A. Loh, W. R. Cook, T. van der Storm.
-**[Managed Data: Modular Strategies for Data Abstraction](https://www.cs.utexas.edu/~wcook/Drafts/2012/ensodata.pdf)**.
-In Proceedings of *Onward!*, 2012.
+[#](#springer2016) M. Springer, H. Masuhara. **[Object Support in an Array-Based GPGPU Extension for Ruby](https://m-sp.org/downloads/array16.pdf)**. In Proceedings of the 3rd International Workshop on Libraries, Languages, and Compilers for Array Programming (ARRAY), 2016.
 
-<a class="paper" name="vanderstorm2012" href="#vanderstorm2012">#</a>
-T. van der Storm, A. Loh, W. R. Cook.
-**[Object Grammars: Compositional & Bidirectional Mapping Between Text and Graphs](https://www.cs.utexas.edu/~wcook/Drafts/2012/ensogrammars.pdf)**.
-In Proceedings of the 5th International Conference on Software Language Engineering, 2012.
+[#](#daloze2016) B. Daloze, S. Marr, D. Bonetta, H. Mössenböck. **[Efficient and Thread-Safe Objects for Dynamically-Typed Languages](https://ssw.jku.at/General/Staff/Daloze/thread-safe-objects.pdf)**. In Proceedings of the Conference on Object-Oriented Programming, Systems, Languages, and Applications (OOPSLA), 2016.
 
-<a class="paper" name="mairhofer2011" href="#mairhofer2011">#</a>
-S. Mairhofer, R. Feldt, R. Torkar, S. Poulding.
-**[Search-Based Software Testing and Test Data Generation for a Dynamic Programming Language](https://arxiv.org/pdf/1804.09232.pdf)**.
-In Proceedings of the 13th Annual Conference on Genetic and Evolutionary Computation, 2011.
+<span class="badge badge-warning">TruffleRuby</span>
 
-<a class="paper" name="guenther2010b" href="#guenther2010b">#</a>
-S. Günther, M. Fischer.
-**[Metaprogramming in Ruby - A Pattern Catalog](https://www.hillside.net/plop/2010/papers/ACMVersions/papers/gunther-1.pdf)**.
-In Proceedings of the 17th Conference on Pattern Languages of Programs, 2010.
+[#](#alcazarzapien2015) J. Alcázar Zapién. **[Debugging Parallel Programs Using Fork Handlers](https://modprobe.files.wordpress.com/2015/09/jalcazar_pmam20151.pdf)**. In Proceedings of the Sixth International Workshop on Programming Models and Applications for Multicores and Manycores (PMAM), 2015.
 
-<a class="paper" name="guenther2010a" href="#guenther2010a">#</a>
-S. Günther, T. Cleenewerck.
-**[Design Principles for Internal Domain-Specific Languages: A Pattern Catalog Illustrated by Ruby](https://www.hillside.net/plop/2010/papers/ACMVersions/papers/gunther-2.pdf)**.
-In Proceedings of the 17th Conference on Pattern Languages of Programs, 2010.
+<span class="badge badge-danger">MRI</span>
 
-<a class="paper" name="guenther2010c" href="#guenther2010c">#</a>
-S. Günther, S. Sunkle.
-**[Dynamically Adaptable Software Product Lines using Ruby Metaprogramming](https://www.se.cs.uni-saarland.de/apel/FOSD2010/80-guenther.pdf)**.
-In Proceedings of the 2nd International Workshop on Feature-Oriented Software Development, 2010.
+[#](#ding2015) C. Ding, B. Gernhardt, P. Li, M. Hertz. **[Safe Parallel Programming in an Interpreted Language](http://polaris.cs.uiuc.edu/hpsl/abstracts/a7-ding.pdf)**. In Proceedings of the First Workshop on the High Performance Scripting Languages, 2015.
 
-<a class="paper" name="guenther2009" href="#guenther2009">#</a>
-S. Günther, S. Sunkle.
-**[Feature-Oriented Programming with Ruby](https://dl.acm.org/doi/abs/10.1145/1629716.1629721)**.
-Technical report, 2009.
+<span class="badge badge-danger">MRI</span>
 
-<a class="paper" name="guenther2009b" href="#guenther2009b">#</a>
-S. Günther, S. Sunkle.
-**[Enabling Feature-Oriented Programming in Ruby](https://www.inf.ovgu.de/inf_media/downloads/forschung/technical_reports_und_preprints/2009/2009_internet/TechReport16-p-2226.pdf)**.
-In Proceedings of the 1st International Workshop on Feature-Oriented Software Development, 2009.
+[#](#lu2014) L. Lu, W. Ji, M. L. Scott. **[Dynamic Enforcement of Determinism in a Parallel Scripting Language](https://www.cs.rochester.edu/u/scott/papers/2014_PLDI_DPR.pdf)**. In Proceedings of the 35th Conference on Programming Language Design and Implementation (PLDI), 2014\. ([source code](https://github.com/RB-DPR/RB-DPR))
+
+<span class="badge badge-info">JRuby</span>
+
+[#](#odaira2014) R. Odaira, J. G. Castanos, H. Tomari. **[Eliminating Global Interpreter Locks in Ruby Through Hardware Transactional Memory](https://researcher.watson.ibm.com/researcher/files/jp-ODAIRA/PPoPP2014_RubyGILHTM.pdf)**. In Proceedings of the 19th Symposium on Principles and Practice of Parallel Programming (PPoPP), 2014.
+
+<span class="badge badge-danger">MRI</span>
+
+[#](#ji2013) W. Ji, L. Lu, M. L. Scott. **[TARDIS: Task-level Access Race Detection by Intersecting Sets](https://wodet.cs.washington.edu/wp-content/uploads/2013/03/wodet2013-final9.pdf)**. In Proceedings of the 4th Workshop on Determinism and Correctness in Parallel Programming (WoDet), 2013.
+
+<span class="badge badge-info">JRuby</span>
+
+[#](#masuhara2012) H. Masuhara, Y. Nishiguchi. **[A Data-Parallel Extension to Ruby for GPGPU - Toward a Framework for Implementing Domain-Specific Optimizations](https://dl.acm.org/doi/abs/10.1145/2237887.2237888)**. In Proceedings of the 9th ECOOP Workshop on Reflection, AOP, and Meta-Data for Software Evolution, 2012.
+
 <span class="badge badge-dark">Paywall</span>
 
-<a class="paper" name="oritz08" href="#oritz08">#</a>
-A. Oritz.
-**[Language Design and Implementation Using Ruby and the Interpreter Pattern](http://34.212.143.74/publicaciones/sif.pdf)**.
-In Proceedings of the 39th SIGCSE Technical Symposium on Computer Science Education, 2008.
+[#](#nakagawa2012) H. Nakagawa, K. Sasada. **[Design and Implementation of Efficient Interprocess Transfer and Sharing Mechanism for Ruby Objects](https://ipsj.ixsq.nii.ac.jp/ej/index.php?action=pages_view_main&active_action=repository_action_common_download&item_id=83710&item_no=1&attribute_id=1&file_no=1&page_id=13&block_id=8)**. In the IPSJ Journal of Programming (PRO), 2012\. _In Japanese_.
 
-<a class="paper" name="geebelen2008" href="#geebelen2008">#</a>
-K. Geebelen, S. Michiels, W. Joosen.
-**[Dynamic Reconfiguration Using Template Based Web Service Composition](https://dl.acm.org/doi/abs/10.1145/1462802.1462811)**.
-In Proceedings of the 3rd Workshop on Middleware for Service Oriented Computing, 2008.
+<span class="badge badge-danger">MRI</span>
+
+<!-- link is flaky -->
+
+ [#](#sasada2012) K. Sasada, S. Urabe, Y. Matsumoto, K Hiraki. **[Parallel Processing on Multiple Virtual Machine for Ruby](https://www.atdot.net/~ko1/activities/sasada_mvm_paper.pdf)**. In the IPSJ Journal of Programming (PRO), 2012\. _In Japanese_.
+
+<span class="badge badge-danger">MRI</span>
+
+[#](#sasada2011) K. Sasada. **[The Improvement of Thread Implementation for Ruby Interpreter](https://www.atdot.net/~ko1/activities/prosym2011-thread_kaizen_paper.pdf)**. In the IPSJ Programming Symposium, 2011\. _In Japanese_.
+
+<span class="badge badge-danger">MRI</span>
+
+[#](#sillito2008) J. Sillito. **[Stage: Exploring Erlang Style Concurrency in Ruby](https://dl.acm.org/doi/abs/10.1145/1370082.1370092)**. In Proceedings of the 1st International Workshop on Multicore Software Engineering, 2008.
+
 <span class="badge badge-dark">Paywall</span>
 
-<a class="paper" name="sheehan07" href="#sheehan07">#</a>
-R. J. Scheehan.
-**[Teaching Operating Systems With Ruby](https://dl.acm.org/doi/10.1145/1268784.1268798)**.
-In Proceedings of the 12th Annual SIGCSE Conference on Innovation and Technology in Computer Science Education, 2007.
+[#](#sasada2007) K. Sasada, Y. Matsumoto, A. Maeda, M. Namiki. **[An Implementation of Parallel Threads for YARV: Yet Another RubyVM](https://www.atdot.net/~ko1/activities/yarv2007thread.pdf)**. In the IPSJ Journal of Programming (PRO), 2007\. _In Japanese_.
+
+<span class="badge badge-danger">MRI</span>
+
+# Type Systems
+
+[#](#guria2021) S. N. Guria, J. S. Foster, D. Van Horn. **[RbSyn: Type- and Effect-Guided Program Synthesis](https://arxiv.org/pdf/2102.13183.pdf)**. In Proceedings of the 42nd ACM SIGPLAN Conference on Programming Language Design and Implementation (PLDI), 2021.
+
+[#](#kazerounian2019) M. Kazerounian, S. N. Guria, N. Vazou, J. S. Foster, D. Van Horn. **[Type-level Computations for Ruby Libraries](https://arxiv.org/pdf/1904.03521.pdf)**. In Proceedings of the 40th ACM SIGPLAN Conference on Programming Language Design and Implementation (PLDI), 2019.
+
+[#](#kazerounian2018) M. Kazerounian, N. Vazou, A. Bourgerie, J. S. Foster, E. Torlak. **[Refinement Types for Ruby](https://arxiv.org/pdf/1711.09281.pdf)**. In Proceedings of the 19th International Conference on Verification, Model Checking, and Abstract Interpretation (VMCAI), 2018.
+
+[#](#ren2016) B. M. Ren, J. S. Foster. **[Just-in-Time Static Type Checking for Dynamic Languages](http://www.cs.tufts.edu/~jfoster/papers/pldi16.pdf)**. In Proceedings of the 37th Conference on Programming Language Design and Implementation (PLDI), 2016.
+
+[#](#ren2013) B. M. Ren, J. Toman, T. S. Strickland, J. S. Foster. **[The Ruby Type Checker](http://www.cs.tufts.edu/~jfoster/papers/oops13.pdf)**. In Proceedings of the 28th Symposium on Applied Computing (SAC), 2013.
+
+[#](#an2011) J. An, A. Chaudhuri, J. S. Foster, M. Hicks. **[Dynamic Inference of Static Types for Ruby](http://www.cs.tufts.edu/~jfoster/papers/popl11.pdf)**. In Proceedings of the 38th ACM Symposium on Principles of Programming Languages (POPL), 2011.
+
+[#](#edgar2011) M. J. Edgar. **[Static Analysis for Ruby in the Presence of Gradual Typing](https://digitalcommons.dartmouth.edu/cgi/viewcontent.cgi?article=1071&context=senior_theses)**. Bachelor's thesis, 2011.
+
+[#](#furr2009b) M. Furr, J. An, J. S. Foster, M. Hicks. **[Static Typing for Ruby on Rails](http://www.cs.umd.edu/projects/PL/druby/papers/drails-ase09.pdf)**. In Proceedings of the 24th Annual ACM Symposium on Applied Computing, 2009.
+
+[#](#furr2009a) M. Furr, J. An, J. S. Foster. **[Work In Progress: an Empirical Study of Static Typing in Ruby](http://www.cs.umd.edu/projects/PL/druby/papers/druby-pilot-plateau09.pdf)**. In Proceedings of the PLATEAU Workshop on Evaluation and Usability of Programming Languages and Tools, 2009.
+
+[#](#daly2009) M. Daly, V. Sazawal, J. S. Foster. **[Profile-Guided Static Typing for Dynamic Scripting Languages](http://www.cs.umd.edu/projects/PL/druby/papers/druby-oopsla09.pdf)**. In Proceedings of the Conference on Object-Oriented Programming, Systems, Languages, and Applications (OOPSLA), 2009.
+
+[#](#an2009) J. An, A. Chaudhuri, J. S. Foster. **[Static Type Inference for Ruby](http://www.cs.umd.edu/projects/PL/druby/papers/druby-oops09.pdf)**. In Proceedings of the 24th IEEE/ACM International Conference on Automated Software Engineering, 2009.
+
+[#](#madsen2007) M. Madsen, P. Sørensen, K. Kristensen. **[Ecstatic - Type Inference for Ruby Using the Cartesian Product Algorithm](https://projekter.aau.dk/projekter/files/61071016/1181807983.pdf)**. Master's thesis, Aalborg University, 2007.
+
+# Garbage Collection
+
+[#](#powers2019) B. Powers, D. Tench, E. D. Berger, A. McGregor. **[Mesh: Compacting Memory Management for C/C++ Applications](https://arxiv.org/pdf/1902.04738.pdf)**. In Proceedings of the 40th ACM SIGPLAN Conference on Programming Language Design and Implementation (PLDI), 2019.
+
+# Tooling
+
+[#](#gaikwad2018) S. Gaikwad, A. Nisbet, M. Luján. **[Performance Analysis for Languages Hosted on the Truffle Framework](https://dl.acm.org/doi/10.1145/3237009.3237019)**. In Proceedings of the 15th International Conference on Managed Languages and Runtimes (MANLANG), 2018.
+
+<span class="badge badge-warning">TruffleRuby</span>
+
 <span class="badge badge-dark">Paywall</span>
 
-### Security
+[#](#kreindl2018) J. Kreindl, M. Rigger, H. Mössenböck. **[Debugging Native Extensions of Dynamic Languages](https://arxiv.org/pdf/1808.00823.pdf)**. In Proceedings of 15th International Conference on Managed Languages & Runtimes (ManLang), 2018.
 
-<a class="paper" name="near2016" href="#near2016">#</a>
-J. P. Near, D. Jackson.
-**[Finding Security Bugs in Web Applications using a Catalog of Access Control Patterns](https://dspace.mit.edu/bitstream/handle/1721.1/102281/jnear-icse16.pdf)**.
-In Proceedings of the 38th International Conference on Software Engineering, 2016.
+<span class="badge badge-warning">TruffleRuby</span>
 
-<a class="paper" name="chaudhuri2010" href="#chaudhuri2010">#</a>
-A. Chaudhuri, J. Foster.
-**[Symbolic Security Analysis of Ruby-on-Rails Web Applications](https://cseweb.ucsd.edu/~dstefan/cse291-winter18/papers/rubyx.pdf)**.
-In Proceedings of the 17th Conference on Computer and Communications Security, 2010.
+[#](#vandevanter2018) M. Van De Vanter, C. Seaton, M. Haupt, C. Humer, T. Würthinger. **[Fast, Flexible, Polyglot Instrumentation Support for Debuggers and other Tools](https://arxiv.org/pdf/1803.10201v1.pdf)**. In The Art, Science, and Engineering of Programming, Vol. 2, No. 3, 2018.
 
-### Computer Vision
+<span class="badge badge-warning">TruffleRuby</span>
 
-<a class="paper" name="wedekind2012" href="#wedekind2012">#</a>
-J. Wedekind.
-**[Efficient Implementations of Machine Vision Algorithms using a Dynamically Typed Programming Language](https://s3-eu-west-1.amazonaws.com/pfigshare-u-files/143003/thesis_wedekind.pdf)**.
-PhD thesis, 2012.
+[#](#miranda2016) S. Miranda, E. Rodrigues Jr, M. T. Valente, R. Terra. **[Architecture Conformance Checking in Dynamically Typed Languages](http://www.sergiohenriquemiranda.com.br/publications/2016_jot.pdf)**. In the Journal of Object Technology (JOT), 2016\. <!-- there's two regional conference papers in 2015 from the same authors, but I don't know the conference - I'm assuming the same content went into this journal paper and I'm including only this one -->
 
-### Bioinformatics
+[#](#savrunyeniceri2015) G. Savrun-Yeniçeri, M. L. Van de Vanter, P. Larsen, S. Brunthaler. **[An Efficient and Generic Event-based Profiler Framework for Dynamic Languages](https://dl.acm.org/doi/abs/10.1145/2807426.2807435)**. In Proceedings of the Principles and Practices of Programming on the Java Platform (PPPJ), 2015.
 
-<a class="paper" name="smith2013" href="#smith2013">#</a>
-R. Smith, R. Williamson, D. Ventura, J. T. Prince.
-**[Rubabel: wrapping open Babel with Ruby](https://jcheminf.biomedcentral.com/track/pdf/10.1186/1758-2946-5-35.pdf)**.
-Journal of Cheminformatics, 5(1), 35, 2013.
+<span class="badge badge-warning">TruffleRuby</span>
 
-<a class="paper" name="goto2010" href="#goto2010">#</a>
-N. Goto, P. Prins, M. Nakao, R. Bonnal, J. Aerts, T. Katayama.
-**[Bioruby: bioinformatics software for the Ruby programming language](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2951089/pdf/btq475.pdf)**.
-Bioinformatics, 26(20):2617–9, Oct 2010.
+<span class="badge badge-dark">Paywall</span>
 
-### Robotics
+[#](#seaton2014) C. Seaton, M. L. Van De Vanter, M. Haupt. **[Debugging at Full Speed](https://www.lifl.fr/dyla14/papers/dyla14-3-Debugging_at_Full_Speed.pdf)**. In Proceedings of the 8th Workshop on Dynamic Languages and Applications (DYLA), 2014\. ([source code](https://web.archive.org/web/20150117042919/https://lafo.ssw.uni-linz.ac.at/truffle/debugging/dyla14-debugging-artifact-0557a4f756d4.tar.gz))
 
-<a class="paper" name="roman2007" href="#roman2007">#</a>
-B. Roman, C. Scholin, S. Jensen, E. Massion, R. Marin III, C. Preston, D. Greenfield, W. Jones, K. Wheeler.
-**[Controlling a Robotic Marine Environmental Sampler with the Ruby Scripting Language](https://journals.sagepub.com/doi/pdf/10.1016/j.jala.2006.07.013)**.
-JALA - Journal of the Association for Laboratory Automation, 12(1), 56-61, 2007.
+<span class="badge badge-warning">TruffleRuby</span>
 
-### Modeling and Simulation
+[#](#sunaga2012) T. Sunaga, K. Sasada. **[Design and Implementation of Real-time Profilers for Scripting Languages](https://www.jstage.jst.go.jp/article/jssst/29/4/29_4_95/_pdf)**. In the JSSST Computer Software (2012). _In Japanese_.
 
-<a class="paper" name="cuadrado2006" href="#cuadrado2006">#</a>
-J. S. Cuadrado, J. G. Molina, M. M. Tortosa.
-**[RubyTL: A Practical, Extensible Transformation Language](https://link.springer.com/chapter/10.1007/11787044_13)**.
-Model Driven Architecture - Foundations and Applications, 2006.
+<span class="badge badge-danger">MRI</span>
+
+[#](#nijjar2011) J. Nijjar, T. Bultan. **[Bounded Verification of Ruby on Rails Data Models](https://sites.cs.ucsb.edu/~bultan/publications/issta11.pdf)**. In Proceedings of the 2011 International Symposium on Software Testing and Analysis, 2011.
+
+# Software Engineering
+
+[#](#rodrigues2018) E. Rodrigues, R. S. Durelli, R. W. de Bettio, L. Montecchi, R. Terra. **[Refactorings for Replacing Dynamic Instructions with Static Ones: the Case of Ruby](https://dl.acm.org/doi/abs/10.1145/3264637.3264645)**. In Proceedings of the XXII Brazilian Symposium on Programming Languages (SBLP), 2018\. _In Portuguese._
+
+<span class="badge badge-dark">Paywall</span>
+
+[#](#kikvas2017) R. Kikvas, G. Gousious, M. Dumas, D. Pfahl. **[Structure and Evolution of Package Dependency Networks](https://github.com/amilajack/reading/blob/master/Computer_Science/Structure%20and%20Evolution%20of%20Package%20Dependency%20Networks.pdf)**. In Proceedings of the 14th International Conference on Mining Software Repositories, 2017.
+
+[#](#salem2016) P. Salem. **[Practical Programming, Validation and Verification with Finite-State Machines: a Library and its Industrial Application](https://dl.acm.org/doi/abs/10.1145/2889160.2889226)**. In Proceedings of the 38th International Conference on Software Engineering Companion (ICSE), 2016.
+
+<span class="badge badge-dark">Paywall</span>
+
+[#](#strickland2014) T. S. Strickland, B. M. Ren, J. S. Foster. **[Contracts for Domain-Specific Languages in Ruby](http://www.cs.tufts.edu/~jfoster/papers/dls12.pdf)**. In Proceedings of the 10th Symposium on Dynamic Languages (DLS), 2014.
+
+[#](#pasquier2014) T. F. J.-M. Pasquier, J. Bacon, B. Shand. **[FlowR: Aspect Oriented Programming for Information Flow Control in Ruby](https://scholar.harvard.edu/files/tfjmp/files/2014modularity.pdf)**. In Proceedings of the 13th International Conference on Modularity (MODULARITY), 2014.
+
+[#](#pancelet2012) T. Poncelet, L. Vigneron. **[The Phenomenal Gem - Putting Features as a Service on Rails](https://raw.githubusercontent.com/phenomenal/rphenomenal/master/public/The_Phenomenal_Gem_Poncelet_Vigneron_2012.pdf)**. Master's thesis, Université Catholique de Louvain, 2012.
+
+[#](#loh2012) A. Loh, W. R. Cook, T. van der Storm. **[Managed Data: Modular Strategies for Data Abstraction](https://www.cs.utexas.edu/~wcook/Drafts/2012/ensodata.pdf)**. In Proceedings of _Onward!_, 2012.
+
+[#](#vanderstorm2012) T. van der Storm, A. Loh, W. R. Cook. **[Object Grammars: Compositional & Bidirectional Mapping Between Text and Graphs](https://www.cs.utexas.edu/~wcook/Drafts/2012/ensogrammars.pdf)**. In Proceedings of the 5th International Conference on Software Language Engineering, 2012.
+
+[#](#mairhofer2011) S. Mairhofer, R. Feldt, R. Torkar, S. Poulding. **[Search-Based Software Testing and Test Data Generation for a Dynamic Programming Language](https://arxiv.org/pdf/1804.09232.pdf)**. In Proceedings of the 13th Annual Conference on Genetic and Evolutionary Computation, 2011.
+
+[#](#guenther2010b) S. Günther, M. Fischer. **[Metaprogramming in Ruby - A Pattern Catalog](https://www.hillside.net/plop/2010/papers/ACMVersions/papers/gunther-1.pdf)**. In Proceedings of the 17th Conference on Pattern Languages of Programs, 2010.
+
+[#](#guenther2010a) S. Günther, T. Cleenewerck. **[Design Principles for Internal Domain-Specific Languages: A Pattern Catalog Illustrated by Ruby](https://www.hillside.net/plop/2010/papers/ACMVersions/papers/gunther-2.pdf)**. In Proceedings of the 17th Conference on Pattern Languages of Programs, 2010.
+
+[#](#guenther2010c) S. Günther, S. Sunkle. **[Dynamically Adaptable Software Product Lines using Ruby Metaprogramming](https://www.se.cs.uni-saarland.de/apel/FOSD2010/80-guenther.pdf)**. In Proceedings of the 2nd International Workshop on Feature-Oriented Software Development, 2010.
+
+[#](#guenther2009) S. Günther, S. Sunkle. **[Feature-Oriented Programming with Ruby](https://dl.acm.org/doi/abs/10.1145/1629716.1629721)**. Technical report, 2009.
+
+[#](#guenther2009b) S. Günther, S. Sunkle. **[Enabling Feature-Oriented Programming in Ruby](https://www.inf.ovgu.de/inf_media/downloads/forschung/technical_reports_und_preprints/2009/2009_internet/TechReport16-p-2226.pdf)**. In Proceedings of the 1st International Workshop on Feature-Oriented Software Development, 2009.
+
+<span class="badge badge-dark">Paywall</span>
+
+[#](#oritz08) A. Oritz. **[Language Design and Implementation Using Ruby and the Interpreter Pattern](http://34.212.143.74/publicaciones/sif.pdf)**. In Proceedings of the 39th SIGCSE Technical Symposium on Computer Science Education, 2008.
+
+[#](#geebelen2008) K. Geebelen, S. Michiels, W. Joosen. **[Dynamic Reconfiguration Using Template Based Web Service Composition](https://dl.acm.org/doi/abs/10.1145/1462802.1462811)**. In Proceedings of the 3rd Workshop on Middleware for Service Oriented Computing, 2008.
+
+<span class="badge badge-dark">Paywall</span>
+
+[#](#sheehan07) R. J. Scheehan. **[Teaching Operating Systems With Ruby](https://dl.acm.org/doi/10.1145/1268784.1268798)**. In Proceedings of the 12th Annual SIGCSE Conference on Innovation and Technology in Computer Science Education, 2007.
+
+<span class="badge badge-dark">Paywall</span>
+
+# Security
+
+[#](#near2016) J. P. Near, D. Jackson. **[Finding Security Bugs in Web Applications using a Catalog of Access Control Patterns](https://dspace.mit.edu/bitstream/handle/1721.1/102281/jnear-icse16.pdf)**. In Proceedings of the 38th International Conference on Software Engineering, 2016.
+
+[#](#chaudhuri2010) A. Chaudhuri, J. Foster. **[Symbolic Security Analysis of Ruby-on-Rails Web Applications](https://cseweb.ucsd.edu/~dstefan/cse291-winter18/papers/rubyx.pdf)**. In Proceedings of the 17th Conference on Computer and Communications Security, 2010.
+
+# Computer Vision
+
+[#](#wedekind2012) J. Wedekind. **[Efficient Implementations of Machine Vision Algorithms using a Dynamically Typed Programming Language](https://s3-eu-west-1.amazonaws.com/pfigshare-u-files/143003/thesis_wedekind.pdf)**. PhD thesis, 2012.
+
+# Bioinformatics
+
+[#](#smith2013) R. Smith, R. Williamson, D. Ventura, J. T. Prince. **[Rubabel: wrapping open Babel with Ruby](https://jcheminf.biomedcentral.com/track/pdf/10.1186/1758-2946-5-35.pdf)**. Journal of Cheminformatics, 5(1), 35, 2013.
+
+[#](#goto2010) N. Goto, P. Prins, M. Nakao, R. Bonnal, J. Aerts, T. Katayama. **[Bioruby: bioinformatics software for the Ruby programming language](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2951089/pdf/btq475.pdf)**. Bioinformatics, 26(20):2617–9, Oct 2010.
+
+# Robotics
+
+[#](#roman2007) B. Roman, C. Scholin, S. Jensen, E. Massion, R. Marin III, C. Preston, D. Greenfield, W. Jones, K. Wheeler. **[Controlling a Robotic Marine Environmental Sampler with the Ruby Scripting Language](https://journals.sagepub.com/doi/pdf/10.1016/j.jala.2006.07.013)**. JALA - Journal of the Association for Laboratory Automation, 12(1), 56-61, 2007.
+
+# Electronic Design Automation
+
+[#](#lelann2020) J-C. Le Lann, H. Badier, F. Kermarrec. **[Towards a Hardware DSL Ecosystem : RubyRTL and friends](https://arxiv.org/abs/2004.09858)**. OSDA - Open Source Design Automation workshop, collocated with DATE Conference, Design Automation and Test in Europe, 2020.
+
+# Modeling and Simulation
+
+[#](#cuadrado2006) J. S. Cuadrado, J. G. Molina, M. M. Tortosa. **[RubyTL: A Practical, Extensible Transformation Language](https://link.springer.com/chapter/10.1007/11787044_13)**. Model Driven Architecture - Foundations and Applications, 2006.
+
 <span class="badge badge-dark">Paywall</span>
 
 ## Standards
 
-<a class="paper" name="iso" href="#iso">#</a>
-IPA Ruby Standardization WG.
-**[ISO/IEC 30170:2012 Information technology — Programming languages — Ruby](https://www.iso.org/standard/59579.html)**.
-The Ruby ISO standard, 2012.
+[#](#iso) IPA Ruby Standardization WG. **[ISO/IEC 30170:2012 Information technology -- Programming languages -- Ruby](https://www.iso.org/standard/59579.html)**. The Ruby ISO standard, 2012.
+
 <span class="badge badge-dark">Paywall</span>


### PR DESCRIPTION
I think the appearance issue is fixed now (was due to a malicious atom package that modified the md itself).